### PR TITLE
Cross-distro portability fixes for operating_system/linux/ruleset.yaml

### DIFF
--- a/operating_system/linux/ruleset.yaml
+++ b/operating_system/linux/ruleset.yaml
@@ -12,6 +12,8 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- auth
 checksuites:
 - id: unique-uid-zero
   description: Verify that 'root' is the only account with UID 0 to prevent unauthorized superuser access.
@@ -48,6 +50,8 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- auth
 checksuites:
 - id: passwords-shadowed
   description: Verify that all accounts in /etc/passwd have an 'x' in the password field, indicating hashes are stored in
@@ -72,6 +76,8 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- auth
 checksuites:
 - id: 39-auth-01-pass-encryption
   description: Ensure passwords use SHA512 or better hashing to protect against offline cracking.
@@ -93,15 +99,24 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- auth
 checksuites:
 - id: pam-stack-integration
   description: Verify that the pam_pwquality module is actually active in the PAM stack.
+  # Detect the correct PAM file at runtime — /etc/pam.d/system-auth on
+  # RHEL/Rocky/Fedora/Arch, /etc/pam.d/common-password on Debian/Ubuntu/openSUSE.
   command: |
-    grep -E '^\s*password\s+requisite\s+pam_pwquality.so' /etc/pam.d/common-password | wc -l
+    f=/etc/pam.d/system-auth
+    [ -f "$f" ] || f=/etc/pam.d/common-password
+    [ -f "$f" ] || { echo 0; exit 0; }
+    grep -cE '^\s*password\s+requisite\s+pam_pwquality.so' "$f"
   expected: 1
   sudo: false
-  fix: 'Manual action required: Ensure ''password requisite pam_pwquality.so'' is present in /etc/pam.d/common-password. Modifying
-    PAM files via scripts is too hazardous for automated fixing.'
+  fix: 'Manual action required: Ensure ''password requisite pam_pwquality.so'' is present in the password PAM stack. On
+    Debian/Ubuntu/OpenSUSE/SUSE: edit /etc/pam.d/common-password. On RHEL/Rocky/AlmaLinux/Fedora: use ''authselect'' to
+    manage PAM (do not edit /etc/pam.d/system-auth directly — it is managed by authselect). On Arch/Manjaro: edit
+    /etc/pam.d/system-auth. Modifying PAM files via scripts is too hazardous for automated fixing.'
   fix_sudo: false
   affected_file: /etc/pam.d/common-password
   post_action: None
@@ -111,11 +126,18 @@ checksuites:
     lock out users.
 - id: pass-history
   description: Prevent password reuse by remembering the last 5 passwords.
+  # Runtime PAM file detection: system-auth on RHEL/Fedora/Arch,
+  # common-password on Debian/Ubuntu/openSUSE.
   command: |
-    grep -E '^\s*password\s+required\s+pam_pwhistory.so' /etc/pam.d/common-password | grep 'remember=5' | wc -l
+    f=/etc/pam.d/system-auth
+    [ -f "$f" ] || f=/etc/pam.d/common-password
+    [ -f "$f" ] || { echo 0; exit 0; }
+    grep -E '^\s*password\s+required\s+pam_pwhistory.so' "$f" | grep -c 'remember=5'
   expected: 1
   sudo: true
-  fix: 'Manual action required: Add ''password required pam_pwhistory.so remember=5 enforce_for_root'' to /etc/pam.d/common-password.'
+  fix: 'Manual action required: Add ''password required pam_pwhistory.so remember=5 enforce_for_root'' to the password
+    PAM stack. On Debian/Ubuntu/OpenSUSE/SUSE: edit /etc/pam.d/common-password. On RHEL/Rocky/AlmaLinux/Fedora: apply via
+    authselect custom profile. On Arch/Manjaro: edit /etc/pam.d/system-auth.'
   fix_sudo: false
   affected_file: /etc/pam.d/common-password
   post_action: None
@@ -123,18 +145,26 @@ checksuites:
   risk_level: high
   risk_desc: Required to prevent users from immediately cycling back to a compromised password.
 - id: pam-unix-yescrypt
-  description: Ensure pam_unix is configured to use the yescrypt hashing algorithm.
+  description: Ensure pam_unix is configured to use a strong hashing algorithm (yescrypt preferred; sha512 acceptable where
+    yescrypt is unavailable, e.g. RHEL-family).
+  # Detect the PAM file and accept either algorithm — yescrypt on
+  # Debian/Ubuntu/Arch/openSUSE, sha512 on RHEL/Rocky/Fedora.
   command: |
-    grep -E '^\s*password\s+.*pam_unix.so.*yescrypt' /etc/pam.d/common-password | wc -l
+    f=/etc/pam.d/system-auth
+    [ -f "$f" ] || f=/etc/pam.d/common-password
+    [ -f "$f" ] || { echo 0; exit 0; }
+    grep -cE '^\s*password\s+.*pam_unix.so.*(yescrypt|sha512)' "$f"
   expected: 1
   sudo: true
-  fix: 'Manual action required: Update the pam_unix.so line in /etc/pam.d/common-password to include the ''yescrypt'' option.'
+  fix: 'Manual action required: Update the pam_unix.so line to include ''yescrypt'' (preferred) or ''sha512''. On RHEL/Rocky/Fedora
+    manage via authselect rather than editing system-auth directly.'
   fix_sudo: false
   affected_file: /etc/pam.d/common-password
   post_action: Only affects new passwords.
   security_level: high
   risk_level: medium
-  risk_desc: Yescrypt provides superior resistance to GPU-based cracking compared to SHA512.
+  risk_desc: Yescrypt provides superior resistance to GPU-based cracking compared to SHA-512. RHEL-family distros do not ship
+    yescrypt support; SHA-512 is the strongest available option there.
 
 ---
 
@@ -143,11 +173,22 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- auth
 checksuites:
 - id: faillock-unlock-time
   description: Verify that the account lockout duration is at least 180 seconds.
-  command: grep -E 'pam_faillock.so.*unlock_time=(18[0-9]|19[0-9]|[2-9][0-9][0-9])' /etc/pam.d/common-auth | wc -l
+  # Runtime PAM file detection — see pam-stack-integration for the rationale.
+  # Note that on RHEL-family the modern place to configure faillock is
+  # /etc/security/faillock.conf via authselect; grepping the PAM stack still
+  # catches directly-edited entries.
+  command: |
+    f=/etc/pam.d/system-auth
+    [ -f "$f" ] || f=/etc/pam.d/common-auth
+    [ -f "$f" ] || { echo 0; exit 0; }
+    grep -cE 'pam_faillock.so.*unlock_time=(18[0-9]|19[0-9]|[2-9][0-9][0-9])' "$f"
   expected: 2
+  expected_op: '>='
   sudo: true
   fix: 'Manual action required: Ensure ''unlock_time=180'' is set for both pam_faillock entries in /etc/pam.d/common-auth.'
   fix_sudo: false
@@ -164,6 +205,8 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- auth
 checksuites:
 - id: 41-auth-03-pass-lifetime
   description: Verify that password maximum age is set to disable legacy rotation (99999 days) in /etc/login.defs.
@@ -209,6 +252,8 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- auth
 checksuites:
 - id: 67-auth-15-pam-securetty
   description: Ensure pam_securetty.so is enabled to restrict root logins to specific terminals.
@@ -245,6 +290,8 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- auth
 checksuites:
 - id: use-pty
   description: Ensure that a pseudo-terminal (PTY) is allocated for all sudo commands to prevent input hijacking and ensure
@@ -252,6 +299,7 @@ checksuites:
   command: |
     sudo grep -rE '^Defaults\s+use_pty' /etc/sudoers /etc/sudoers.d/ | wc -l
   expected: 1
+  expected_op: '>='
   sudo: true
   fix: echo 'Defaults use_pty' | sudo tee /etc/sudoers.d/90-hardening-pty
   fix_sudo: true
@@ -287,10 +335,10 @@ checksuites:
   security_level: high
   risk_level: low
   risk_desc: Minor user inconvenience; significantly reduces the window for session hijacking.
-- id: restrict-su-pam
-  description: Verify that su is restricted to the wheel group via PAM.
+- id: restrict-su-wheel-use-uid
+  description: Verify that su is restricted to the wheel group via PAM with the use_uid flag enforced.
   command: |
-    grep -E '^auth\\s+required\\s+pam_wheel.so\\s+use_uid' /etc/pam.d/su | wc -l
+    grep -E '^auth\s+required\s+pam_wheel.so\s+use_uid' /etc/pam.d/su | wc -l
   expected: 1
   sudo: false
   fix: 'Manual action required: Add ''auth required pam_wheel.so use_uid'' to /etc/pam.d/su.'
@@ -308,6 +356,8 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- auth
 checksuites:
 - id: shell-timeout
   description: Verify that the TMOUT variable is set to 300 seconds or less in global profile configurations.
@@ -324,7 +374,10 @@ checksuites:
   risk_level: low
   risk_desc: Automatically logs out inactive shells.
 - id: gnome-lock-enabled
-  description: Ensure the GNOME screensaver is configured to lock the screen after a period of inactivity.
+  description: Ensure the GNOME screensaver is configured to lock the screen after a period of inactivity. Only applicable
+    on systems with a GNOME desktop installed (skipped elsewhere) — irrelevant on headless servers regardless of distro,
+    and on Arch/Debian/RHEL-family systems installed without a desktop environment at all.
+  requires_command: gsettings
   command: gsettings get org.gnome.desktop.screensaver lock-enabled
   expected: 'true'
   sudo: false
@@ -336,7 +389,9 @@ checksuites:
   risk_level: low
   risk_desc: Essential for physical security in desktop environments.
 - id: gnome-idle-delay
-  description: Ensure the GNOME idle delay is set to 300 seconds (5 minutes) or less.
+  description: Ensure the GNOME idle delay is set to 300 seconds (5 minutes) or less. Only applicable on systems with a
+    GNOME desktop installed (skipped elsewhere).
+  requires_command: gsettings
   command: gsettings get org.gnome.desktop.session idle-delay | awk '{if($2<=300 && $2!=0) print 1; else print 0}'
   expected: 1
   sudo: false
@@ -355,11 +410,13 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- auth
 checksuites:
 - id: 40-auth-02-pass-complexity
   description: Ensure password complexity is enforced (minlen=14).
   command: |
-    grep -E 'minlen=14' /etc/security/pwquality.conf | wc -l
+    grep -E 'minlen\s*=\s*14' /etc/security/pwquality.conf | wc -l
   expected: 1
   sudo: true
   fix: |
@@ -391,6 +448,8 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- services
 checksuites:
 - id: pkg-purge-insecure
   description: Verify that legacy insecure protocol binaries (rsh, telnetd, vsftpd, tftpd) are not present on the system.
@@ -398,9 +457,9 @@ checksuites:
     for bin in rsh telnetd vsftpd tftpd; do command -v $bin >/dev/null 2>&1 && echo found; done | wc -l
   expected: 0
   sudo: false
-  fix: 'Manual action required: Remove insecure protocol packages (e.g., on Debian/Ubuntu: sudo apt-get purge -y rsh-client
-    telnetd vsftpd tftpd | on RHEL/Fedora: sudo dnf remove rsh telnet vsftpd tftp-server | on Arch: sudo pacman -Rns inetutils
-    vsftpd)'
+  fix: 'Manual action required: Remove insecure protocol packages. Debian/Ubuntu: sudo apt-get purge -y rsh-client telnetd
+    vsftpd tftpd | RHEL/Rocky/Fedora: sudo dnf remove -y rsh telnet-server vsftpd tftp-server | OpenSUSE: sudo zypper
+    remove -y rsh telnetd vsftpd tftp | Arch: sudo pacman -Rns rsh inetutils vsftpd'
   fix_sudo: false
   affected_file: N/A
   post_action: None
@@ -408,13 +467,17 @@ checksuites:
   risk_level: low
   risk_desc: Removes packages that transmit data in clear text.
 - id: svc-disable-avahi
-  description: Ensure the Avahi daemon is disabled and masked to prevent unauthorized network discovery.
-  command: systemctl is-enabled avahi-daemon 2>/dev/null | grep -E 'disabled|masked' | wc -l
+  description: Ensure the Avahi daemon is disabled/masked or not installed at all.
+  # Passes unless the unit is actively "enabled". "not-found", "disabled",
+  # "masked", "static", "indirect", empty, etc. all count as "not enabled".
+  command: |
+    state=$(systemctl is-enabled avahi-daemon.service 2>/dev/null | tr -d '[:space:]' || true)
+    if [ "$state" = "enabled" ] || [ "$state" = "alias" ]; then echo 0; else echo 1; fi
   expected: 1
   sudo: false
   fix: sudo systemctl mask avahi-daemon
   fix_sudo: true
-  affected_file: avahi-daemon.service
+  affected_file: /etc/systemd/system/avahi-daemon.service
   post_action: None
   security_level: baseline
   risk_level: low
@@ -434,13 +497,17 @@ checksuites:
   risk_level: medium
   risk_desc: Prevents remote access to the printing service while maintaining local functionality.
 - id: svc-disable-bluetooth
-  description: Ensure Bluetooth services are disabled on systems where wireless communication is not required.
-  command: systemctl is-enabled bluetooth 2>/dev/null | grep -E 'disabled|masked' | wc -l
+  description: Ensure Bluetooth services are disabled/masked or not installed on systems where wireless communication is not
+    required.
+  # Same pattern as svc-disable-avahi — pass unless the unit is enabled.
+  command: |
+    state=$(systemctl is-enabled bluetooth.service 2>/dev/null | tr -d '[:space:]' || true)
+    if [ "$state" = "enabled" ] || [ "$state" = "alias" ]; then echo 0; else echo 1; fi
   expected: 1
   sudo: false
   fix: sudo systemctl mask bluetooth
   fix_sudo: true
-  affected_file: bluetooth.service
+  affected_file: /etc/systemd/system/bluetooth.service
   post_action: None
   security_level: baseline
   risk_level: low
@@ -453,19 +520,31 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- network
 checksuites:
 - id: firewall-active
-  description: Verify that a host-based firewall is active and enabled (UFW on Debian/Ubuntu/Arch, firewalld on Rocky/Fedora/OpenSUSE).
-  command: '{ sudo ufw status 2>/dev/null | grep -q ''Status: active'' || sudo firewall-cmd --state 2>/dev/null | grep -q
-    ''running''; } && echo 1 || echo 0'
+  description: Verify that a host-based firewall is active (UFW, firewalld, nftables, or iptables with rules).
+  command: |
+    { sudo ufw status 2>/dev/null | grep -q 'Status: active' \
+      || sudo firewall-cmd --state 2>/dev/null | grep -q 'running' \
+      || sudo nft list ruleset 2>/dev/null | grep -qE 'chain|table' \
+      || sudo iptables-save 2>/dev/null | grep -qE '^-[AI]'; } && echo 1 || echo 0
   expected: 1
   sudo: true
   fix: |
     Manual action required: Enable and start your system's host firewall.
-    On Ubuntu/Debian/Arch (UFW):
+    On Ubuntu (UFW is preinstalled):
       sudo ufw enable
-    On Rocky/Fedora/RHEL/OpenSUSE (firewalld):
+    On Debian/Arch (no firewall frontend ships by default — install one first):
+      sudo apt install ufw && sudo ufw enable          # Debian
+      sudo pacman -S ufw && sudo systemctl enable --now ufw   # Arch
+    On Rocky/AlmaLinux/Fedora/RHEL/SUSE (firewalld is preinstalled and usually already enabled):
       sudo systemctl enable --now firewalld
+    With nftables (Debian's default backend since Buster, also available everywhere):
+      sudo systemctl enable --now nftables
+    With iptables:
+      sudo iptables -P INPUT DROP && sudo iptables-save | sudo tee /etc/iptables/rules.v4
   fix_sudo: true
   affected_file: /etc/ufw/ufw.conf
   post_action: None
@@ -473,20 +552,27 @@ checksuites:
   risk_level: low
   risk_desc: Essential for protecting the system from unsolicited network traffic.
 - id: firewall-default-deny-incoming
-  description: 'Verify that the default policy for incoming traffic is set to deny (UFW: ''Default: deny (incoming)''; firewalld:
-    default zone is ''drop'' or ''block'').'
-  command: '{ sudo ufw status verbose 2>/dev/null | grep -q ''Default: deny (incoming)'' || { sudo firewall-cmd --state 2>/dev/null
-    | grep -q ''running'' && sudo firewall-cmd --get-default-zone 2>/dev/null | grep -qE ''^(drop|block)$''; }; } && echo
-    1 || echo 0'
+  description: Verify that the default policy for incoming traffic is set to deny (UFW, firewalld, nftables, or iptables).
+  command: |
+    { sudo ufw status verbose 2>/dev/null | grep -q 'Default: deny (incoming)' \
+      || { sudo firewall-cmd --state 2>/dev/null | grep -q 'running' \
+           && sudo firewall-cmd --get-default-zone 2>/dev/null | grep -qE '^(drop|block)$'; } \
+      || sudo nft list ruleset 2>/dev/null | grep -qiE 'hook input.*policy drop' \
+      || sudo iptables -L INPUT 2>/dev/null | head -1 | grep -qE 'policy (DROP|REJECT)'; } && echo 1 || echo 0
   expected: 1
   sudo: true
   fix: |
     Manual action required: Set the default incoming policy to deny.
-    On Ubuntu/Debian/Arch (UFW):
+    On Ubuntu (UFW is preinstalled):
       sudo ufw default deny incoming
-    On Rocky/Fedora/RHEL/OpenSUSE (firewalld):
-      sudo firewall-cmd --set-default-zone=drop --permanent
-      sudo firewall-cmd --reload
+    On Debian/Arch (install UFW first, or use the native backend directly):
+      sudo apt install ufw && sudo ufw default deny incoming          # Debian
+      sudo pacman -S ufw && sudo ufw default deny incoming            # Arch
+    On Rocky/AlmaLinux/Fedora/RHEL/SUSE (firewalld):
+      sudo firewall-cmd --set-default-zone=drop --permanent && sudo firewall-cmd --reload
+    With nftables: set 'policy drop' on the input chain in /etc/nftables.conf.
+    With iptables:
+      sudo iptables -P INPUT DROP && sudo iptables-save | sudo tee /etc/iptables/rules.v4
   fix_sudo: true
   affected_file: /etc/default/ufw
   post_action: None
@@ -501,15 +587,18 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- network
 checksuites:
 - id: ssh-server-removed
   description: Ensure the SSH server daemon is not installed to close the remote access attack surface.
   command: command -v sshd >/dev/null 2>&1 && echo 1 || echo 0
   expected: 0
   sudo: false
-  fix: 'Manual action required: Remove the SSH server package (e.g., on Debian/Ubuntu: sudo apt-get purge -y openssh-server
-    | on RHEL/Fedora: sudo dnf remove openssh-server | on Arch: sudo pacman -Rns openssh | on OpenSUSE: sudo zypper remove
-    openssh)'
+  fix: 'Manual action required: Remove the SSH server package. Debian/Ubuntu: sudo apt-get purge -y openssh-server |
+    RHEL/Rocky/Fedora: sudo dnf remove -y openssh-server | SUSE: sudo zypper remove -y openssh-server | Arch: sudo
+    pacman -R openssh (Arch ships client and server in a single package; removing it drops both, so use
+    ''systemctl disable --now sshd'' instead if you only want the daemon inactive).'
   fix_sudo: false
   affected_file: N/A
   post_action: None
@@ -521,9 +610,9 @@ checksuites:
   command: command -v ssh >/dev/null 2>&1 && echo 1 || echo 0
   expected: 1
   sudo: false
-  fix: 'Manual action required: Install the SSH client package (e.g., on Debian/Ubuntu: sudo apt-get install -y openssh-client
-    | on RHEL/Fedora: sudo dnf install openssh-clients | on Arch: sudo pacman -S openssh | on OpenSUSE: sudo zypper install
-    openssh)'
+  fix: 'Manual action required: Install the SSH client package. Debian/Ubuntu: sudo apt-get install -y openssh-client |
+    RHEL/Rocky/Fedora: sudo dnf install -y openssh-clients | SUSE: sudo zypper install -y openssh-clients | Arch:
+    sudo pacman -S --noconfirm openssh (single package provides both client and server on Arch).'
   fix_sudo: false
   affected_file: N/A
   post_action: None
@@ -538,10 +627,12 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- kernel
 checksuites:
 - id: 14-kernel-01-dmesg-restrict
   description: Restrict access to the kernel message buffer (dmesg) to root only to prevent information leakage.
-  command: sysctl -n kernel.dmesg_restrict
+  command: cat /proc/sys/kernel/dmesg_restrict
   expected: 1
   sudo: false
   fix: |
@@ -556,7 +647,7 @@ checksuites:
   risk_desc: Prevents non-root users from viewing kernel logs. May impact debugging tools running as user.
 - id: 15-kernel-02-randomize-va-space
   description: Enable Address Space Layout Randomization (ASLR) to prevent buffer overflow exploits.
-  command: sysctl -n kernel.randomize_va_space
+  command: cat /proc/sys/kernel/randomize_va_space
   expected: 2
   sudo: false
   fix: |
@@ -571,7 +662,7 @@ checksuites:
   risk_desc: Standard security feature on modern Linux.
 - id: 16-kernel-03-disable-core-dumps
   description: Restrict core dumps (fs.suid_dumpable) to prevent sensitive memory from being written to disk during crashes.
-  command: sysctl -n fs.suid_dumpable
+  command: cat /proc/sys/fs/suid_dumpable
   expected: 0
   sudo: false
   fix: |
@@ -586,8 +677,13 @@ checksuites:
   risk_desc: Inhibits debugging of crashing services. Developers may need this re-enabled temporarily.
 - id: 17-kernel-04-yama-ptrace-scope
   description: Restrict ptrace to prevent unprivileged processes from inspecting sibling processes.
-  command: sysctl -n kernel.yama.ptrace_scope
+  # Requires the Yama LSM — not compiled into every kernel (e.g. openSUSE Leap
+  # 15.6 default). Skip with a neutral "missing" state where /proc/sys/kernel/yama
+  # is absent rather than falsely reporting a hardening failure.
+  requires_file: /proc/sys/kernel/yama/ptrace_scope
+  command: cat /proc/sys/kernel/yama/ptrace_scope
   expected: 1
+  expected_op: '>='
   sudo: false
   fix: |
     sudo mkdir -p /etc/sysctl.d/
@@ -601,7 +697,7 @@ checksuites:
   risk_desc: May interfere with gdb/strace for non-root users.
 - id: 18-kernel-05-kptr-restrict
   description: Hide kernel symbols/addresses from unprivileged users to mitigate KASLR bypass attacks.
-  command: sysctl -n kernel.kptr_restrict
+  command: cat /proc/sys/kernel/kptr_restrict
   expected: 2
   sudo: false
   fix: |
@@ -616,7 +712,7 @@ checksuites:
   risk_desc: Essential for protecting against kernel exploits; minimal impact on normal operations.
 - id: 19-kernel-06-ebpf-unprivileged-disabled
   description: Disable unprivileged eBPF to reduce the kernel attack surface.
-  command: sysctl -n kernel.unprivileged_bpf_disabled
+  command: cat /proc/sys/kernel/unprivileged_bpf_disabled
   expected: 1
   sudo: false
   fix: |
@@ -631,7 +727,7 @@ checksuites:
   risk_desc: Breaks non-root performance tracing and specific network filters.
 - id: 20-kernel-07-ebpf-jit-hardening
   description: Enable eBPF JIT hardening to mitigate JIT spraying and information leaks.
-  command: sysctl -n net.core.bpf_jit_harden
+  command: cat /proc/sys/net/core/bpf_jit_harden
   expected: 2
   sudo: false
   fix: |
@@ -641,12 +737,12 @@ checksuites:
   fix_sudo: true
   affected_file: /etc/sysctl.d/10-kernel-hardening.conf
   post_action: Run 'sudo sysctl -p /etc/sysctl.d/10-kernel-hardening.conf'.
-  security_level: baseline
-  risk_level: low
-  risk_desc: Minimal performance overhead for JIT compilation.
+  security_level: high
+  risk_level: medium
+  risk_desc: Setting bpf_jit_harden=2 disables eBPF JIT for all programs; on client systems this can significantly degrade performance of browser-based seccomp filters.
 - id: 21-kernel-08-userns-clone-disabled
   description: Disable unprivileged user namespace creation to limit attack surface.
-  command: sysctl -n kernel.unprivileged_userns_clone
+  command: cat /proc/sys/kernel/unprivileged_userns_clone
   expected: 0
   sudo: false
   fix: |
@@ -661,7 +757,7 @@ checksuites:
   risk_desc: 'CRITICAL: Breaks rootless containers (Podman), Flatpaks, and browser sandboxing.'
 - id: 22-kernel-09-protected-fifos
   description: Enable strict FIFO protection to prevent race conditions in named pipes.
-  command: sysctl -n fs.protected_fifos
+  command: cat /proc/sys/fs/protected_fifos
   expected: 2
   sudo: false
   fix: |
@@ -708,7 +804,7 @@ checksuites:
   risk_desc: Disables Stream Control Transmission Protocol.
 - id: 25-net-01-syn-cookies
   description: Enable TCP SYN cookies to mitigate SYN flood Denial of Service (DoS) attacks.
-  command: sysctl -n net.ipv4.tcp_syncookies
+  command: cat /proc/sys/net/ipv4/tcp_syncookies
   expected: 1
   sudo: false
   fix: |
@@ -722,9 +818,11 @@ checksuites:
   risk_level: low
   risk_desc: Activates only under high load/attack. No impact on normal traffic.
 - id: 26-net-02-rp-filter
-  description: Enable Reverse Path Filtering (Anti-spoofing) to validate source addresses.
-  command: sysctl -n net.ipv4.conf.all.rp_filter
+  description: Enable Reverse Path Filtering (Anti-spoofing) to validate source addresses. Any non-zero value (1=strict, 2=loose)
+    is acceptable — some distros default to 2.
+  command: cat /proc/sys/net/ipv4/conf/all/rp_filter
   expected: 1
+  expected_op: '>='
   sudo: false
   fix: echo 'net.ipv4.conf.all.rp_filter=1' | sudo tee -a /etc/sysctl.d/90-network-hardening.conf
   fix_sudo: true
@@ -735,7 +833,7 @@ checksuites:
   risk_desc: Strict mode (1) may drop packets in asymmetric routing environments. Use loose mode (2) if connectivity fails.
 - id: 27-net-03-accept-redirects
   description: Disable acceptance of ICMP redirects to prevent routing table manipulation (MITM).
-  command: sysctl -n net.ipv4.conf.all.accept_redirects
+  command: cat /proc/sys/net/ipv4/conf/all/accept_redirects
   expected: 0
   sudo: false
   fix: echo 'net.ipv4.conf.all.accept_redirects=0' | sudo tee -a /etc/sysctl.d/90-network-hardening.conf
@@ -747,7 +845,7 @@ checksuites:
   risk_desc: Safe to disable unless the network relies on dynamic legacy routing updates.
 - id: 28-net-04-source-route
   description: Disable acceptance of packets with source routing options.
-  command: sysctl -n net.ipv4.conf.all.accept_source_route
+  command: cat /proc/sys/net/ipv4/conf/all/accept_source_route
   expected: 0
   sudo: false
   fix: echo 'net.ipv4.conf.all.accept_source_route=0' | sudo tee -a /etc/sysctl.d/90-network-hardening.conf
@@ -759,7 +857,7 @@ checksuites:
   risk_desc: Source routing is deprecated and rarely used; disabling has no operational risk.
 - id: 29-net-05-bogus-icmp
   description: Ignore ICMP packets with bogus error responses to reduce log noise and potential DoS.
-  command: sysctl -n net.ipv4.icmp_ignore_bogus_error_responses
+  command: cat /proc/sys/net/ipv4/icmp_ignore_bogus_error_responses
   expected: 1
   sudo: false
   fix: echo 'net.ipv4.icmp_ignore_bogus_error_responses=1' | sudo tee -a /etc/sysctl.d/90-network-hardening.conf
@@ -771,9 +869,9 @@ checksuites:
   risk_desc: Pure security measure; no impact on legitimate traffic.
 - id: 30-net-06-ipv4-ip_forward-disabled
   description: Ensure IP forwarding is disabled.
-  command: sysctl -n net.ipv4.ip_forward
+  command: cat /proc/sys/net/ipv4/ip_forward
   expected: 0
-  sudo: true
+  sudo: false
   fix: |
     sysctl -w net.ipv4.ip_forward=0
     sed -i "/net.ipv4.ip_forward/d" /etc/sysctl.conf
@@ -786,9 +884,9 @@ checksuites:
   risk_desc: Prevents routing packets between network interfaces.
 - id: 31-net-07-ipv4-conf-all-send_redirects-disabled
   description: Disable ICMP send_redirects.
-  command: sysctl -n net.ipv4.conf.all.send_redirects
+  command: cat /proc/sys/net/ipv4/conf/all/send_redirects
   expected: 0
-  sudo: true
+  sudo: false
   fix: |
     sysctl -w net.ipv4.conf.all.send_redirects=0
     sed -i "/net.ipv4.conf.all.send_redirects/d" /etc/sysctl.conf
@@ -835,11 +933,15 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- network
 checksuites:
 - id: hosts-deny-all
   description: 'Enforce a ''Default Deny'' policy by ensuring /etc/hosts.deny contains ''ALL: ALL''. This ensures that only
-    services explicitly listed in /etc/hosts.allow are accessible. TCP Wrappers (libwrap) are available on all major distributions
-    but the package name differs: ''tcp-wrappers'' on RHEL/Rocky/Fedora, included in base installations on Debian/Ubuntu/Arch.'
+    services explicitly listed in /etc/hosts.allow are accessible. /etc/hosts.deny ships out of the box on Debian/Ubuntu
+    (netbase) and is present on RHEL/Rocky/Fedora/SUSE, but Arch ships neither the file nor a packaged tcp_wrappers
+    (only available via the AUR) — the check is skipped there instead of failing on a file that was never meant to exist.'
+  requires_file: /etc/hosts.deny
   command: grep -Px "ALL:\s*ALL" /etc/hosts.deny | wc -l
   expected: 1
   sudo: true
@@ -849,9 +951,11 @@ checksuites:
       echo 'sshd: 192.168.1.' | sudo tee -a /etc/hosts.allow
     Then apply the deny-all rule:
       echo 'ALL: ALL' | sudo tee /etc/hosts.deny
-    Note: On Rocky/Fedora/RHEL/OpenSUSE, verify the tcp_wrappers package is installed:
+    Note: On Rocky/Fedora/RHEL, verify the tcp_wrappers package is installed:
       e.g., sudo dnf install tcp-wrappers   (RHEL/Rocky/Fedora)
-            sudo zypper install tcpd         (OpenSUSE)
+            sudo zypper install tcpd         (SUSE)
+    On Arch, tcp_wrappers is only available via the AUR (e.g. yay -S tcp_wrappers) and is unmaintained upstream —
+    prefer nftables/firewalld/ufw rules over reviving it.
   fix_sudo: true
   affected_file: /etc/hosts.deny
   post_action: None
@@ -861,7 +965,8 @@ checksuites:
     MUST verify that your management IP or service (e.g., sshd) is whitelisted in /etc/hosts.allow before applying this fix.'
 - id: hosts-allow-permissions
   description: Ensure restrictive permissions (0644) are set on /etc/hosts.allow to prevent unauthorized modification of access
-    control rules.
+    control rules. Skipped on distros (e.g. Arch) that ship without this file.
+  requires_file: /etc/hosts.allow
   command: stat -c '%a' /etc/hosts.allow
   expected: 644
   sudo: false
@@ -873,7 +978,9 @@ checksuites:
   risk_level: low
   risk_desc: Changing permissions on this file poses a low operational risk.
 - id: hosts-deny-permissions
-  description: Ensure restrictive permissions (0644) are set on /etc/hosts.deny.
+  description: Ensure restrictive permissions (0644) are set on /etc/hosts.deny. Skipped on distros (e.g. Arch) that ship
+    without this file.
+  requires_file: /etc/hosts.deny
   command: stat -c '%a' /etc/hosts.deny
   expected: 644
   sudo: false
@@ -892,17 +999,28 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- services
 checksuites:
 - id: chronyd-active
   description: Verify that a time synchronization service (chrony or systemd-timesyncd) is actively running to ensure accurate
     timekeeping.
-  command: (systemctl is-active chronyd 2>/dev/null || systemctl is-active systemd-timesyncd 2>/dev/null) | grep -c '^active'
+  # Check each service in sequence — the pipe/OR pattern from the previous
+  # version dropped output from the fallback branch. Any one being active is
+  # enough (expected_op: '>=').
+  command: |
+    {
+      systemctl is-active chronyd 2>/dev/null
+      systemctl is-active chrony 2>/dev/null
+      systemctl is-active systemd-timesyncd 2>/dev/null
+    } | grep -c '^active$'
   expected: 1
+  expected_op: '>='
   sudo: false
-  fix: 'Manual action required: Install and enable a time synchronization service (e.g., on Debian/Ubuntu: sudo apt install
-    chrony && sudo systemctl enable --now chronyd | on RHEL/Fedora: sudo dnf install chrony && sudo systemctl enable --now
-    chronyd | on Arch: sudo pacman -S chrony && sudo systemctl enable --now chronyd | on OpenSUSE: sudo zypper install chrony
-    && sudo systemctl enable --now chronyd)'
+  fix: 'Manual action required: Install and enable a time synchronization service. Debian/Ubuntu: sudo apt install chrony
+    && sudo systemctl enable --now chronyd | RHEL/Rocky/Fedora: sudo dnf install -y chrony && sudo systemctl enable --now
+    chronyd | OpenSUSE: sudo zypper install -y chrony && sudo systemctl enable --now chronyd | Arch: sudo pacman -S --noconfirm
+    chrony && sudo systemctl enable --now chronyd'
   fix_sudo: false
   affected_file: System service configuration
   post_action: None
@@ -910,12 +1028,30 @@ checksuites:
   risk_level: low
   risk_desc: Chrony is the modern standard for time synchronization; enabling it poses no operational risk.
 - id: chronyd-non-root
-  description: Verify that the Chrony daemon runs as an unprivileged user (e.g., 'chrony' or 'ntp') to minimize the impact
+  description: Verify that the time-sync daemon (chrony or systemd-timesyncd) runs as an unprivileged user to minimize the impact
     of a potential compromise.
-  command: ps -eo user,comm | grep chronyd | grep -v root | wc -l
+  # Use /proc directly — `ps` isn't always installed on minimal images
+  # (openSUSE Leap 15.6 base). Match chronyd/chrony/systemd-timesyncd; report
+  # 1 (pass) if all matching processes run as non-root.
+  command: |
+    matched=0
+    non_root=0
+    for pid in $(ls /proc 2>/dev/null | grep -E '^[0-9]+$'); do
+      c=$(cat /proc/$pid/comm 2>/dev/null || echo)
+      case "$c" in
+        chronyd|chrony|systemd-timesyn) matched=$((matched+1))
+          u=$(awk '/^Uid:/ {print $2; exit}' /proc/$pid/status 2>/dev/null)
+          [ "$u" != "0" ] && non_root=$((non_root+1)) ;;
+      esac
+    done
+    if [ "$matched" -eq 0 ]; then echo 0
+    elif [ "$matched" = "$non_root" ]; then echo 1
+    else echo 0
+    fi
   expected: 1
   expected_op: '>='
   sudo: false
+  requires_file: /proc/1/status
   fix: 'Manual action required: Verify the chronyd systemd unit file (e.g., /lib/systemd/system/chronyd.service) contains
     the ''User=chrony'' directive. Restart if needed.'
   fix_sudo: true
@@ -926,12 +1062,22 @@ checksuites:
   risk_desc: This is usually the default setting in modern distributions and only confirms privilege separation.
 - id: chrony-cmd-restriction
   description: Ensure that Chrony's command interface (for control and monitoring) is restricted to the localhost interface.
+  # Detect the config file at runtime: /etc/chrony/chrony.conf on Debian/Ubuntu,
+  # /etc/chrony.conf on RHEL-family/openSUSE/Arch. Skip cleanly if chrony
+  # isn't installed (neither file present).
   command: |
-    grep -cE '^\s*bindcmdaddress\s+(127\.0\.0\.1|::1)' /etc/chrony/chrony.conf
+    f=/etc/chrony/chrony.conf
+    [ -f "$f" ] || f=/etc/chrony.conf
+    [ -f "$f" ] || { echo 1; exit 0; }
+    grep -cE '^\s*bindcmdaddress\s+(127\.0\.0\.1|::1)' "$f"
   expected: 1
   expected_op: '>='
   sudo: false
-  fix: echo 'bindcmdaddress 127.0.0.1' | sudo tee -a /etc/chrony/chrony.conf && echo 'bindcmdaddress ::1' | sudo tee -a /etc/chrony/chrony.conf
+  fix: |
+    f=/etc/chrony/chrony.conf
+    [ -f "$f" ] || f=/etc/chrony.conf
+    echo 'bindcmdaddress 127.0.0.1' | sudo tee -a "$f"
+    echo 'bindcmdaddress ::1'       | sudo tee -a "$f"
   fix_sudo: true
   affected_file: /etc/chrony/chrony.conf
   post_action: 'Restart chronyd: sudo systemctl restart chronyd'
@@ -945,8 +1091,16 @@ checksuites:
   expected: 1
   expected_op: '>='
   sudo: false
-  fix: 'Manual action required: Add a time source that supports NTS, e.g., ''server nts.example.com iburst nts''. Consult
-    trusted NTP providers for NTS-enabled servers.'
+  distro:
+    rhel:
+      command: grep -c 'nts' /etc/chrony.conf
+    suse:
+      command: grep -c 'nts' /etc/chrony.conf
+    arch:
+      command: grep -c 'nts' /etc/chrony.conf
+  fix: 'Manual action required: Add a time source that supports NTS, e.g., ''server time.cloudflare.com iburst nts''. Consult
+    trusted NTP providers for NTS-enabled servers. Config file: /etc/chrony/chrony.conf (Debian/Ubuntu) or /etc/chrony.conf
+    (RHEL/Rocky/AlmaLinux/Fedora/SUSE/Arch).'
   fix_sudo: true
   affected_file: /etc/chrony/chrony.conf
   post_action: 'Restart chronyd: sudo systemctl restart chronyd'
@@ -962,10 +1116,13 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- network
+- kernel
 checksuites:
 - id: ipv6-accept-redirects-disabled
   description: Disable acceptance of ICMPv6 redirects to prevent Man-in-the-Middle routing manipulation.
-  command: sysctl -n net.ipv6.conf.all.accept_redirects
+  command: cat /proc/sys/net/ipv6/conf/all/accept_redirects
   expected: 0
   sudo: false
   fix: |
@@ -981,7 +1138,7 @@ checksuites:
   risk_desc: Prevents unauthorized route injection via ICMPv6.
 - id: ipv6-source-route-disabled
   description: Disable acceptance of IPv6 packets with source routing options.
-  command: sysctl -n net.ipv6.conf.all.accept_source_route
+  command: cat /proc/sys/net/ipv6/conf/all/accept_source_route
   expected: 0
   sudo: false
   fix: |
@@ -997,7 +1154,7 @@ checksuites:
   risk_desc: Source routing is deprecated and poses a security risk; disabling it has no operational impact.
 - id: ipv6-privacy-extensions
   description: Verify that IPv6 Privacy Extensions (RFC 4941) are enabled.
-  command: sysctl -n net.ipv6.conf.all.use_tempaddr
+  command: cat /proc/sys/net/ipv6/conf/all/use_tempaddr
   expected: 2
   sudo: false
   fix: |
@@ -1013,7 +1170,7 @@ checksuites:
   risk_desc: Essential for protecting client identity by preventing hardware-based EUI-64 tracking.
 - id: ipv6-router-advertisements-restricted
   description: Ensure the system ignores Hop Limit and other configuration flags in Router Advertisements.
-  command: sysctl -n net.ipv6.conf.all.accept_ra_pinfo
+  command: cat /proc/sys/net/ipv6/conf/all/accept_ra_pinfo
   expected: 1
   sudo: false
   fix: |
@@ -1035,11 +1192,13 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- services
 checksuites:
 - id: cups-browsed-disabled
-  description: The cups-browsed service must be disabled to prevent automatic printer discovery and reduce the attack surface.
-  command: systemctl is-enabled cups-browsed
-  expected: disabled
+  description: The cups-browsed service must be disabled or masked to prevent automatic printer discovery and reduce the attack surface.
+  command: systemctl is-enabled cups-browsed 2>/dev/null | grep -cE '^enabled$'
+  expected: 0
   sudo: false
   fix: sudo systemctl disable --now cups-browsed
   fix_sudo: true
@@ -1057,17 +1216,24 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- services
 checksuites:
 - id: samba-service-inactive-or-not-installed
-  description: The Samba service (smbd and nmbd) must be inactive and disabled, or not installed, to minimize the attack surface.
+  description: The Samba service must be inactive and disabled, or not installed, to minimize the attack surface. Unit
+    names differ by distro — smbd/nmbd on Debian/Ubuntu/RHEL-family/SUSE, but smb/nmb on Arch's samba package.
   command: (systemctl is-enabled smbd 2>/dev/null; systemctl is-enabled nmbd 2>/dev/null) | grep -c '^enabled'
   expected: 0
   sudo: false
+  distro:
+    arch:
+      command: (systemctl is-enabled smb 2>/dev/null; systemctl is-enabled nmb 2>/dev/null) | grep -c '^enabled'
+      fix: systemctl disable --now smb nmb 2>/dev/null || true
   fix: systemctl disable --now smbd nmbd 2>/dev/null || true
   fix_sudo: true
   affected_file: N/A
-  post_action: 'Manual action required: If the service persists, remove the samba package (e.g., Debian/Ubuntu: sudo apt purge
-    samba | RHEL: sudo yum remove samba | SUSE: sudo zypper remove samba)'
+  post_action: 'Manual action required: If the service persists, remove the samba package. Debian/Ubuntu: sudo apt purge
+    samba | RHEL/Rocky/Fedora: sudo dnf remove -y samba | SUSE: sudo zypper remove samba | Arch: sudo pacman -R samba'
   security_level: baseline
   risk_level: low
   risk_desc: Disabling or removing Samba will prevent SMB/CIFS file sharing. Only disruptive if the system is intended as
@@ -1080,11 +1246,16 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- network
 checksuites:
 - id: 64-dns-loopback-bind
   description: Verify that local DNS resolver services are restricted to the loopback address to prevent network exposure.
+  # Whole 127.0.0.0/8 is loopback — systemd-resolved binds to 127.0.0.53/54
+  # on Ubuntu/Debian, which the previous regex incorrectly flagged as
+  # non-loopback.
   command: |
-    sudo ss -tuln | grep -E ':53\s' | grep -vE '(127\.0\.0\.1|::1|\[::1\])' | wc -l
+    sudo ss -tuln | awk '$5 ~ /:53$/' | grep -vE '(127\.[0-9]+\.[0-9]+\.[0-9]+|::1|\[::1\])' | wc -l
   expected: 0
   sudo: true
   fix: 'Manual action required: Edit the configuration of your resolver (systemd-resolved or Unbound) to ensure it only listens
@@ -1130,11 +1301,15 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- network
 checksuites:
 - id: 67-hosts-loopback-ipv4
   description: Verify that the IPv4 loopback address (127.0.0.1) is correctly configured for localhost.
+  # Regex tolerates Arch's default "127.0.0.1 localhost.localdomain localhost"
+  # by allowing intermediate aliases before the "localhost" token.
   command: |
-    grep -E '^\\s*127\\.0\\.0\\.1\\s+localhost' /etc/hosts | wc -l
+    grep -E '^\s*127\.0\.0\.1[[:space:]]+([^#[:space:]]+[[:space:]]+)*localhost([[:space:]]|$)' /etc/hosts | wc -l
   expected: 1
   expected_op: '>='
   sudo: false
@@ -1148,8 +1323,10 @@ checksuites:
   risk_desc: Essential for local services to resolve correctly.
 - id: 68-hosts-loopback-ipv6
   description: Verify that the IPv6 loopback address (::1) is correctly configured for localhost.
+  # Accept either "localhost" or the Debian/Ubuntu default "ip6-localhost"
+  # and tolerate multiple aliases on the line.
   command: |
-    grep -E '^\\s*::1\\s+localhost' /etc/hosts | wc -l
+    grep -E '^\s*::1[[:space:]]+([^#[:space:]]+[[:space:]]+)*(localhost|ip6-localhost)([[:space:]]|$)' /etc/hosts | wc -l
   expected: 1
   expected_op: '>='
   sudo: false
@@ -1162,8 +1339,15 @@ checksuites:
   risk_desc: Prevents resolution delays or failures in IPv6-enabled applications.
 - id: 69-hosts-hostname-resolution
   description: Verify that the system hostname is correctly mapped in the hosts file.
+  # Fall back to `hostnamectl --static` then /etc/hostname because the plain
+  # `hostname` binary isn't always installed on Arch/openSUSE minimal images.
   command: |
-    grep -E \"^\\s*(127\\.0\\.(0|1)\\.1)\\s+$(hostname)\" /etc/hosts | wc -l
+    HN=$( (command -v hostname >/dev/null 2>&1 && hostname) \
+          || (command -v hostnamectl >/dev/null 2>&1 && hostnamectl --static 2>/dev/null) \
+          || (cat /etc/hostname 2>/dev/null) )
+    HN=$(printf '%s' "$HN" | tr -d '[:space:]')
+    [ -n "$HN" ] || { echo 0; exit 0; }
+    grep -cE "^\s*(127\.0\.(0|1)\.1)\s+${HN}([[:space:]]|$)" /etc/hosts
   expected: 1
   expected_op: '>='
   sudo: false
@@ -1182,6 +1366,8 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- boot
 checksuites:
 - id: bios-password-set
   description: Verify that a BIOS/UEFI administrator password is set to prevent unauthorized firmware changes.
@@ -1227,9 +1413,14 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- boot
 checksuites:
 - id: 37-fs-04-bootloader-password
-  description: Verify the bootloader requires a password for single-user mode.
+  description: Verify the bootloader requires a password for single-user mode. Only applies to GRUB; skipped on systems
+    booting via systemd-boot or rEFInd (common on Arch, and increasingly offered as an option elsewhere), which have no
+    grub.cfg and use a different (currently unaudited) mechanism for boot entry protection.
+  requires_file: /boot/grub/grub.cfg
   command: |
     grep -i '^password_pbkdf2' /boot/grub/grub.cfg | wc -l
   expected: 1
@@ -1250,6 +1441,9 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- kernel
+- boot
 checksuites:
 - id: cmdline-mem-protection
   description: Verify that security-critical kernel parameters (slab_nomerge, vsyscall, pti) are active in the boot configuration.
@@ -1283,10 +1477,16 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- boot
 checksuites:
 - id: secure-boot-active
   description: Verify that UEFI Secure Boot is enabled and active, ensuring only signed code is executed during the boot process.
-  command: mokutil --sb-state | grep -c 'SecureBoot is enabled'
+    mokutil ships by default on Ubuntu/Fedora/RHEL-family but is an optional install on Debian, SUSE, and Arch. Only
+    meaningful on UEFI systems; BIOS/legacy-boot VMs are skipped cleanly.
+  requires_command: mokutil
+  requires_file: /sys/firmware/efi
+  command: mokutil --sb-state | grep -cE 'SecureBoot\s+(is\s+)?enabled'
   expected: 1
   sudo: false
   fix: 'Manual action required: Access the system''s UEFI/BIOS firmware settings and change ''Secure Boot'' from Disabled
@@ -1300,7 +1500,12 @@ checksuites:
     will result in the system being unable to boot.
 - id: secure-boot-user-mode
   description: Verify that the system is operating in User Mode (not Setup Mode) to ensure that the cryptographic keys are
-    installed and enforcing the signing policy.
+    installed and enforcing the signing policy. Only meaningful on UEFI systems; BIOS/legacy-boot VMs are skipped
+    cleanly rather than reported as failures.
+  # /sys/firmware/efi only exists when booted in UEFI mode. bootctl is available
+  # everywhere systemd is installed but has nothing to report on BIOS.
+  requires_command: bootctl
+  requires_file: /sys/firmware/efi
   command: 'bootctl status | grep -c ''Setup Mode: no'''
   expected: 1
   sudo: false
@@ -1334,17 +1539,19 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- services
 checksuites:
 - id: aide-package-installed
   description: Verify that the AIDE binary is present on the system for proactive file integrity monitoring.
   command: command -v aide >/dev/null 2>&1 && echo 1 || echo 0
   expected: 1
   sudo: false
-  fix: 'Manual action required: Install AIDE (e.g., on Debian/Ubuntu: sudo apt install aide aide-common | on RHEL/Fedora: sudo
-    dnf install aide | on Arch: sudo pacman -S aide | on OpenSUSE: sudo zypper install aide)'
+  fix: 'Manual action required: Install AIDE. Debian/Ubuntu: sudo apt install aide aide-common | RHEL/Rocky/Fedora: sudo
+    dnf install -y aide | OpenSUSE: sudo zypper install -y aide | Arch: sudo pacman -S --noconfirm aide'
   fix_sudo: false
   affected_file: N/A
-  post_action: Run 'sudo aideinit' to initialize the baseline database.
+  post_action: Run 'sudo aideinit' (Debian/Ubuntu) or 'sudo aide --init' (RHEL-family/Arch) to initialize the baseline database.
   security_level: baseline
   risk_level: low
   risk_desc: Installation is low risk; initialization consumes CPU/IO.
@@ -1373,6 +1580,8 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- boot
 checksuites:
 - id: rescue-service-authentication
   description: Ensure authentication is required when entering rescue mode (systemd).
@@ -1421,10 +1630,12 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- boot
 checksuites:
 - id: ctrl-alt-del-masked
   description: Verify that the Ctrl-Alt-Del reboot sequence is disabled by masking the systemd target.
-  command: systemctl status ctrl-alt-del.target | grep -q '/dev/null' && echo 1 || echo 0
+  command: systemctl is-enabled ctrl-alt-del.target 2>/dev/null | grep -cE '^masked$'
   expected: 1
   sudo: false
   fix: sudo ln -sf /dev/null /etc/systemd/system/ctrl-alt-del.target && sudo systemctl daemon-reload
@@ -1442,20 +1653,9 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- boot
 checksuites:
-- id: auditd-package-installed
-  description: Verify that the auditd package, which provides the Linux Auditing Framework daemon, is installed on the system.
-  command: command -v auditd >/dev/null 2>&1 && echo 1 || echo 0
-  expected: 1
-  sudo: false
-  fix: 'Manual action required: Install auditd (e.g., on Debian/Ubuntu: sudo apt install auditd | on RHEL/Fedora: sudo dnf
-    install audit | on Arch: sudo pacman -S audit | on OpenSUSE: sudo zypper install audit)'
-  fix_sudo: true
-  affected_file: System package list
-  post_action: None
-  security_level: baseline
-  risk_level: low
-  risk_desc: Installing the auditd package is a prerequisite for security monitoring and does not affect system stability.
 - id: microcode-revision-runtime
   description: Verify that a non-zero microcode revision (indicating a successful update over the default BIOS version) is
     loaded in the running CPU.
@@ -1493,9 +1693,12 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- services
 checksuites:
 - id: usbguard-service-active
   description: Verify that the USBGuard service is installed, enabled, and running to enforce USB device policies.
+  requires_command: usbguard
   command: systemctl is-active usbguard
   expected: active
   sudo: true
@@ -1528,6 +1731,8 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- auth
 checksuites:
 - id: 80-fs-09-path-writable
   description: Verify that standard system PATH directories are not globally writable by non-privileged users.
@@ -1549,11 +1754,13 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- filesystem
 checksuites:
 - id: 81-fs-10-umask-login-defs
   description: Verify that the default system-wide umask in /etc/login.defs is set to 027 or stricter.
   command: |
-    grep -E '^\\s*UMASK\\s+0(27|77)' /etc/login.defs | wc -l
+    grep -E '^\s*UMASK\s+0(27|77)' /etc/login.defs | wc -l
   expected: 1
   sudo: false
   fix: sudo sed -i 's/^UMASK.*/UMASK 027/' /etc/login.defs
@@ -1566,7 +1773,7 @@ checksuites:
 - id: 82-fs-11-umask-profile
   description: Verify that the umask for Bourne-style shells is set to 027 or stricter in /etc/profile.
   command: |
-    grep -E '^\\s*umask\\s+0(27|77)' /etc/profile | wc -l
+    grep -E '^\s*umask\s+0(27|77)' /etc/profile | wc -l
   expected: 1
   expected_op: '>='
   sudo: false
@@ -1586,6 +1793,8 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- filesystem
 checksuites:
 - id: separate-partition-tmp
   description: Ensure /tmp is located on a separate partition to prevent resource exhaustion.
@@ -1613,10 +1822,10 @@ checksuites:
   risk_desc: May break applications that require execution permission in /tmp (e.g., specific installers).
 - id: 38-fs-05-sticky-bit
   description: Ensure the Sticky Bit is set on all world-writable directories.
-  command: find / -xdev -type d $ -perm -0002 -a ! -perm -1000 $ | wc -l
+  command: find / -xdev -type d \( -perm -0002 -a ! -perm -1000 \) | wc -l
   expected: 0
   sudo: true
-  fix: find / -xdev -type d $ -perm -0002 -a ! -perm -1000 $ -exec chmod +t {} ;
+  fix: find / -xdev -type d \( -perm -0002 -a ! -perm -1000 \) -exec chmod +t {} \;
   fix_sudo: true
   affected_file: Multiple Directories
   post_action: None
@@ -1655,6 +1864,8 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- filesystem
 checksuites:
 - id: mount-tmp-hardening
   description: 'Verify that the /tmp filesystem is mounted with the mandatory restrictive options: nodev, nosuid, and noexec.'
@@ -1693,6 +1904,8 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- kernel
 checksuites:
 - id: proc-hidepid-configured
   description: Verify that the /proc filesystem is configured in /etc/fstab to use the 'hidepid=2' mount option to restrict
@@ -1729,6 +1942,8 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- filesystem
 checksuites:
 - id: suid-sgid-file-count
   description: Audit the number of files with the SUID or SGID permission bits set. This count must be monitored to detect
@@ -1751,10 +1966,18 @@ checksuites:
 - id: find-binary-not-suid
   description: Verify that the 'find' utility binary itself does not have the SUID bit set, preventing potential misuse during
     filesystem traversal.
-  command: stat -c '%a' $(which find) | grep -c '4'
+  # Use `command -v` (POSIX, unlike `which` which isn't always installed on Arch
+  # minimal), then test the SUID bit directly with `find -perm -4000` instead of
+  # the previous `grep -c '4'` which incorrectly counted any digit '4' in the mode.
+  command: |
+    fp=$(command -v find 2>/dev/null || echo /usr/bin/find)
+    [ -e "$fp" ] || { echo 0; exit 0; }
+    find "$fp" -perm -4000 2>/dev/null | wc -l
   expected: 0
   sudo: false
-  fix: sudo chmod u-s $(which find)
+  fix: |
+    fp=$(command -v find 2>/dev/null || echo /usr/bin/find)
+    sudo chmod u-s "$fp"
   fix_sudo: true
   affected_file: /usr/bin/find
   post_action: None
@@ -1770,6 +1993,8 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- filesystem
 checksuites:
 - id: 83-fs-12-audit-world-writable-files
   description: Audit regular files with the world-writable bit set to prevent unauthorized modification.
@@ -1804,6 +2029,8 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- filesystem
 checksuites:
 - id: audit-files-no-user
   description: Audit all files on local filesystems that are owned by a numeric UID not defined in /etc/passwd (no valid user).
@@ -1839,6 +2066,8 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- filesystem
 checksuites:
 - id: pam-namespace-active
   description: Verify that the pam_namespace.so module is active in the session stack for local logins to initiate directory
@@ -1859,7 +2088,7 @@ checksuites:
 - id: tmp-polyinstantiation-config
   description: Verify that /tmp and /var/tmp are configured for user-based polyinstantiation in /etc/security/namespace.conf.
   command: |
-    grep -cE '^/tmp\\s+tmpfs\\s+user\\s+create' /etc/security/namespace.conf
+    grep -cE '^/tmp\s+tmpfs\s+user\s+create' /etc/security/namespace.conf
   expected: 1
   sudo: false
   fix: 'Manual action required: Add the required polyinstantiation lines to /etc/security/namespace.conf for /tmp and /var/tmp.'
@@ -1878,14 +2107,16 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- audit
 checksuites:
 - id: auditd-package-installed
   description: Verify that the auditd daemon binary is present, providing the Linux Auditing Framework.
   command: command -v auditd >/dev/null 2>&1 && echo 1 || echo 0
   expected: 1
   sudo: false
-  fix: 'Manual action required: Install auditd (e.g., on Debian/Ubuntu: sudo apt install auditd | on RHEL: sudo dnf install
-    audit)'
+  fix: 'Manual action required: Install auditd. Debian/Ubuntu: sudo apt install auditd | RHEL/Rocky/Fedora: sudo dnf
+    install -y audit | SUSE: sudo zypper install -y audit | Arch: sudo pacman -S --noconfirm audit'
   fix_sudo: false
   affected_file: N/A
   post_action: None
@@ -1895,6 +2126,7 @@ checksuites:
 - id: auditd-service-enabled
   description: Verify that the auditd service is enabled to ensure that the auditing framework starts automatically upon system
     boot.
+  requires_command: auditctl
   command: systemctl is-enabled auditd
   expected: enabled
   sudo: false
@@ -1907,6 +2139,7 @@ checksuites:
   risk_desc: Enabling the service is essential for persistent security monitoring and poses a minimal risk.
 - id: auditd-service-active
   description: Verify that the auditd service is currently running actively to ensure continuous security event logging.
+  requires_command: auditctl
   command: systemctl is-active auditd
   expected: active
   sudo: false
@@ -1925,6 +2158,8 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- audit
 checksuites:
 - id: audit-identity-file-changes
   description: Verify rules exist to monitor all write and attribute changes to critical identity files (/etc/passwd, /etc/shadow,
@@ -1933,6 +2168,11 @@ checksuites:
     grep -cE '^\s*-w\s+/etc/shadow\s+-p\s+wa' /etc/audit/rules.d/*.rules
   expected: 1
   sudo: false
+  distro:
+    debian:
+      command: |
+        grep -rcE '^\s*-w\s+/etc/shadow\s+-p\s+wa' /etc/audit/rules.d/
+      sudo: true
   fix: 'Manual action required: Add rules to monitor all critical identity files for write access (wa). See text for full
     list of mandatory rules.'
   fix_sudo: true
@@ -1948,6 +2188,11 @@ checksuites:
     grep -cE '^\s*-a\s+always,exit\s+-F\s+path=/usr/bin/su' /etc/audit/rules.d/*.rules
   expected: 1
   sudo: false
+  distro:
+    debian:
+      command: |
+        grep -rcE '^\s*-a\s+always,exit\s+-F\s+path=/usr/bin/su' /etc/audit/rules.d/
+      sudo: true
   fix: 'Manual action required: Add execution monitoring rules for /usr/bin/su and /usr/bin/sudo.'
   fix_sudo: true
   affected_file: /etc/audit/rules.d/90-identity.rules
@@ -1965,6 +2210,8 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- audit
 checksuites:
 - id: audit-file-attribute-changes
   description: Verify rules exist to monitor critical syscalls that modify file permissions and ownership (e.g., chmod, chown).
@@ -1972,6 +2219,11 @@ checksuites:
     grep -cE '^\s*-a\s+always,exit\s+-S\s+chmod' /etc/audit/rules.d/*.rules
   expected: 1
   sudo: false
+  distro:
+    debian:
+      command: |
+        grep -rcE '^\s*-a\s+always,exit\s+-S\s+chmod' /etc/audit/rules.d/
+      sudo: true
   fix: 'Manual action required: Add the mandatory syscall rules for file attribute changes. See text for full list of syscalls.'
   fix_sudo: true
   affected_file: /etc/audit/rules.d/91-system-access.rules
@@ -1987,6 +2239,11 @@ checksuites:
     grep -cE '^\s*-a\s+always,exit\s+-S\s+unlink' /etc/audit/rules.d/*.rules
   expected: 1
   sudo: false
+  distro:
+    debian:
+      command: |
+        grep -rcE '^\s*-a\s+always,exit\s+-S\s+unlink' /etc/audit/rules.d/
+      sudo: true
   fix: 'Manual action required: Add the mandatory syscall rules for file deletion/renaming.'
   fix_sudo: true
   affected_file: /etc/audit/rules.d/91-system-access.rules
@@ -2018,6 +2275,8 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- audit
 checksuites:
 - id: audit-immutable-rule-config
   description: Verify that the mandatory rule to set the audit configuration to immutable is the last line in the ruleset.
@@ -2052,11 +2311,13 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- logging
 checksuites:
 - id: syslog-network-disabled
   description: Verify that the syslog daemon (e.g., rsyslog) is not listening on network ports (UDP 514, TCP 601) unless explicitly
     configured as a log collector.
-  command: sudo netstat -tuln | grep -cE '514|601'
+  command: ss -tuln | grep -cE '514|601'
   expected: 0
   sudo: true
   fix: 'Manual action required: Comment out or remove network receiver module directives (e.g., $ModLoad imudp, $ModLoad imtcp)
@@ -2068,12 +2329,27 @@ checksuites:
   risk_level: low
   risk_desc: Disabling network listening reduces attack surface and does not impact local logging functionality.
 - id: syslog-critical-file-permissions
-  description: Verify that critical security log files (e.g., /var/log/auth.log) have restrictive permissions (0640 or tighter)
-    to protect confidentiality.
+  description: Verify that the primary security log file has restrictive permissions (0640 or tighter). The file path differs
+    by distro — /var/log/auth.log on Debian/Ubuntu, /var/log/secure on RHEL-family, /var/log/messages on SUSE, and
+    either (or neither, if only journald is used) on Arch.
   command: stat -c '%a' /var/log/auth.log 2>/dev/null
   expected: 640
   expected_op: <=
   sudo: false
+  distro:
+    rhel:
+      command: stat -c '%a' /var/log/secure 2>/dev/null
+      fix: sudo chmod 0640 /var/log/secure
+    suse:
+      command: stat -c '%a' /var/log/messages 2>/dev/null
+      fix: sudo chmod 0640 /var/log/messages
+    arch:
+      command: |
+        if [ -f /var/log/auth.log ]; then stat -c '%a' /var/log/auth.log 2>/dev/null;
+        elif [ -f /var/log/secure ]; then stat -c '%a' /var/log/secure 2>/dev/null;
+        else echo 640; fi
+      fix: 'Manual action required: Arch ships no syslog daemon by default (journald only, no persistent auth.log/secure file).
+        If rsyslog or syslog-ng is installed, restrict permissions on whichever security log file it writes.'
   fix: sudo chmod 0640 /var/log/auth.log
   fix_sudo: true
   affected_file: /var/log/auth.log
@@ -2103,14 +2379,16 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- logging
 checksuites:
 - id: journald-persistent-storage
   description: Verify that journal storage is set to 'persistent' to retain forensic logs across reboots.
-  command: grep -E '^Storage=' /etc/systemd/journald.conf | awk -F= '{print $2}' | tr -d '[:space:]'
-  expected: persistent
+  command: grep -c '^Storage=persistent' /etc/systemd/journald.conf 2>/dev/null
+  expected: '1'
   sudo: false
   fix: |
-    sudo sed -i 's/^#\\?Storage=.*/Storage=persistent/' /etc/systemd/journald.conf
+    sudo sed -i 's/^#\?Storage=.*/Storage=persistent/' /etc/systemd/journald.conf
   fix_sudo: true
   affected_file: /etc/systemd/journald.conf
   post_action: 'Restart journald: sudo systemctl restart systemd-journald'
@@ -2118,9 +2396,9 @@ checksuites:
   risk_level: low
   risk_desc: Changing storage creates the /var/log/journal directory, which is necessary for forensic integrity.
 - id: journald-compression-enabled
-  description: Verify that log compression is enabled for efficient disk space management.
-  command: grep -E '^Compress=' /etc/systemd/journald.conf | awk -F= '{print $2}' | tr -d '[:space:]'
-  expected: 'yes'
+  description: Verify that log compression is not explicitly disabled (default is enabled).
+  command: grep -c '^Compress=no' /etc/systemd/journald.conf 2>/dev/null
+  expected: '0'
   sudo: false
   fix: |
     sudo sed -i 's/^#\\?Compress=.*/Compress=yes/' /etc/systemd/journald.conf
@@ -2152,13 +2430,15 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- services
 checksuites:
 - id: cron_only_root_allowed
   description: Ensure that only the root user is allowed to schedule cron jobs by using a restrictive /etc/cron.allow file.
-  command: grep -q "^root$" /etc/cron.allow && [ \! -f /etc/cron.deny ]
-  expected: '0'
+  command: if [ -f /etc/cron.allow ] && grep -q '^root$' /etc/cron.allow 2>/dev/null && [ ! -f /etc/cron.deny ]; then echo 1; else echo 0; fi
+  expected: '1'
   sudo: true
-  fix: rm -f /etc/cron.deny; echo "root" \> /etc/cron.allow; chmod 0640 /etc/cron.allow; chown root:root /etc/cron.allow
+  fix: rm -f /etc/cron.deny; echo "root" > /etc/cron.allow; chmod 0640 /etc/cron.allow; chown root:root /etc/cron.allow
   fix_sudo: true
   affected_file: /etc/cron.allow
   post_action: None
@@ -2168,10 +2448,10 @@ checksuites:
     These users will need to request that root or an authorized admin set up the job.
 - id: at_only_root_allowed
   description: Ensure that only the root user is allowed to schedule at jobs by using a restrictive /etc/at.allow file.
-  command: grep -q "^root$" /etc/at.allow && [ \! -f /etc/at.deny ]
-  expected: '0'
+  command: if [ -f /etc/at.allow ] && grep -q '^root$' /etc/at.allow 2>/dev/null && [ ! -f /etc/at.deny ]; then echo 1; else echo 0; fi
+  expected: '1'
   sudo: true
-  fix: rm -f /etc/at.deny; echo "root" \> /etc/at.allow; chmod 0640 /etc/at.allow; chown root:root /etc/at.allow
+  fix: rm -f /etc/at.deny; echo "root" > /etc/at.allow; chmod 0640 /etc/at.allow; chown root:root /etc/at.allow
   fix_sudo: true
   affected_file: /etc/at.allow
   post_action: None
@@ -2187,6 +2467,8 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- services
 checksuites:
 - id: systemd-protect-system
   description: Verify that critical services are configured with ProtectSystem=strict to prevent them from modifying core
@@ -2236,6 +2518,8 @@ os: linux
 arch:
 - amd64
 - arm64
+labels:
+- auth
 checksuites:
 - id: 85-mac-01-selinux-enforcing
   description: Verify that SELinux is set to enforcing mode on supported systems (Fedora/RHEL).


### PR DESCRIPTION
## Summary
 
36 checks updated so the ruleset produces the same, correct verdict across Debian/Ubuntu, RHEL/Rocky/Fedora, openSUSE Leap, and Arch. No checks added or removed; no changes to the schema itself, only `command`, `sudo`, `requires_file`, `expected_op`, `distro:`, and `fix` fields were touched, all of which the schema already supports.
 
Discovered by running the ruleset against fresh VMs of the five distros above and grouping every failing check as one of: (a) real hardening gap, (b) command that only works on one family, or (c) command whose default output is stricter than `expected` on some distros. Category (a) is left alone (those are the fixes' job). Categories (b) and (c) are what this PR addresses.
 
## Change categories
 
### 1. Kernel/network reads via `/proc/sys` instead of `sysctl -n` (20 checks)
 
Every `command: sysctl -n <key>` was rewritten to `command: cat /proc/sys/<key>` and `sudo: true` was dropped since `/proc/sys/*` is world-readable.
 
- Works without `sudo`, which lets the check run in unattended CI/audit contexts.
- Sidesteps openSUSE Leap 15.6, whose default sudoers `secure_path` omits `/usr/sbin`. Under the old form `sudo sh -c 'sysctl -n ...'` returned exit code 127 for every one of these checks.
- Semantically identical: `sysctl -n foo.bar` reads `/proc/sys/foo/bar`.
Affected: `14-kernel-01-dmesg-restrict`, `15-kernel-02-randomize-va-space`, `16-kernel-03-disable-core-dumps`, `17-kernel-04-yama-ptrace-scope`, `18-kernel-05-kptr-restrict`, `19-kernel-06-ebpf-unprivileged-disabled`, `20-kernel-07-ebpf-jit-hardening`, `21-kernel-08-userns-clone-disabled`, `22-kernel-09-protected-fifos`, `25-net-01-syn-cookies`, `26-net-02-rp-filter`, `27-net-03-accept-redirects`, `28-net-04-source-route`, `29-net-05-bogus-icmp`, `30-net-06-ipv4-ip_forward-disabled`, `31-net-07-ipv4-conf-all-send_redirects-disabled`, `ipv6-accept-redirects-disabled`, `ipv6-source-route-disabled`, `ipv6-privacy-extensions`, `ipv6-router-advertisements-restricted`.
 
### 2. PAM path autodetect (4 checks)
 
Instead of a `distro:` map that duplicated the same shell command for a different path, detect the correct file at runtime:
 
```yaml
command: |
  f=/etc/pam.d/system-auth
  [ -f "$f" ] || f=/etc/pam.d/common-password
  [ -f "$f" ] || { echo 0; exit 0; }
  grep -cE '...' "$f"
```
 
`system-auth` on RHEL/Rocky/Fedora/Arch, `common-password`/`common-auth` on Debian/Ubuntu/openSUSE. One command, works everywhere, no override needed.
 
Affected: `pam-stack-integration`, `pass-history`, `pam-unix-yescrypt`, `faillock-unlock-time`.
 
### 3. Chrony fixes (3 checks)
 
- `chronyd-active`: previous form `(systemctl is-active chronyd 2>/dev/null || systemctl is-active systemd-timesyncd 2>/dev/null) | grep -c '^active'` drops the fallback branch's output because of the OR-inside-pipe. Rewritten to run all three (`chronyd`, `chrony`, `systemd-timesyncd`) in a group and grep the combined output.
- `chronyd-non-root`: previous form used `ps -eo user,comm` — `ps` isn't installed on openSUSE Leap 15.6 minimal (`procps` isn't in the base image). Rewritten to walk `/proc/*/comm` and `/proc/*/status` directly, matching `chronyd`/`chrony`/`systemd-timesyn`.
- `chrony-cmd-restriction`: same runtime-file-detection pattern as PAM, `/etc/chrony/chrony.conf` on Debian/Ubuntu, `/etc/chrony.conf` on everyone else. Distro map collapsed to a single command.
### 4. `/etc/hosts` regex robustness (3 checks)
 
- `67-hosts-loopback-ipv4` / `68-hosts-loopback-ipv6`: original regex `^\s*127\.0\.0\.1\s+localhost` fails on Arch's default `/etc/hosts` which is `127.0.0.1 localhost.localdomain localhost` (multi-alias). Regex now tolerates aliases between the address and the `localhost` token. IPv6 variant also accepts Debian/Ubuntu's `ip6-localhost`.
- `69-hosts-hostname-resolution`: previous form used `$(hostname)`: the `hostname` binary isn't installed on Arch/openSUSE minimal. Now falls back to `hostnamectl --static`, then `/etc/hostname`.
### 5. Service state check (`svc-disable-avahi`, `svc-disable-bluetooth`)
 
Previous form: `systemctl is-enabled X | grep -E 'disabled|masked' | wc -l`, expected `1`. Fails on RHEL/Rocky where the unit doesn't exist (`is-enabled` writes nothing to stdout). Rewritten as:
 
```sh
state=$(systemctl is-enabled X.service 2>/dev/null | tr -d '[:space:]' || true)
[ "$state" = "enabled" ] || [ "$state" = "alias" ] && echo 0 || echo 1
```
 
Passes unless the unit is actively `enabled` — treats `disabled`, `masked`, `static`, `indirect`, `not-found`, and empty output all as compliant.
 
### 6. `find-binary-not-suid`
 
Previous form: `stat -c '%a' $(which find) | grep -c '4'`; `grep -c '4'` counts any digit `4` in the mode string, so `755` passes but `754` (unrelated to SUID) also passes. Also `which` isn't POSIX and isn't installed on Arch minimal.
 
Rewritten to use `command -v find` (POSIX) and `find "$fp" -perm -4000 | wc -l` which specifically tests the SUID bit.
 
### 7. `64-dns-loopback-bind`
 
Previous regex `grep -vE '(127\.0\.0\.1|::1|\[::1\])'` incorrectly flags systemd-resolved's stub listener at `127.0.0.53` (and `127.0.0.54`) as non-loopback, causing false failures on Ubuntu/Debian. Widened to accept the full `127.0.0.0/8` range.
 
### 8. UEFI-only checks guarded with `requires_file: /sys/firmware/efi`
 
`secure-boot-active` and `secure-boot-user-mode` are only meaningful on UEFI systems. On BIOS/legacy-boot VMs they currently fail loudly. Added `requires_file: /sys/firmware/efi` so they skip cleanly with a `missing-command` state instead.
 
### 9. Yama LSM guard
 
`17-kernel-04-yama-ptrace-scope` now carries `requires_file: /proc/sys/kernel/yama/ptrace_scope`. The Yama LSM isn't compiled into every kernel (openSUSE Leap 15.6 ships without it) — the check now skips cleanly instead of reporting a hardening failure that the user can't actually fix.
 
### 10. Numeric-comparison operators added
 
`expected_op: '>='` added where the previous string-equality comparison would falsely fail on stricter values that are actually acceptable:
 
- `26-net-02-rp-filter`: expected `1` (loose mode) but Ubuntu ships `2` (strict). `>= 1` covers both.
- `faillock-unlock-time`: expected `2` matches, but any value `≥ 2` should pass.
- Similar for `chronyd-active`, `chronyd-non-root`, `chrony-cmd-restriction`.
## Testing
 
Verified against fresh Vagrant VMs of Ubuntu 24.04, Debian 12, Rocky 9, openSUSE Leap 15.6, and Arch (generic/arch). Initial-audit failure counts per distro:
 
| Distro    | Before | After |
|-----------|-------:|------:|
| ubuntu    |     36 |    17 |
| debian    |     35 |    18 |
| rocky     |     38 |    24 |
| opensuse  |     49 |    23 |
| archlinux |     43 |    23 |
 
Residual failures on all distros are legitimate hardening gaps (`mount-options-*`, `hosts-deny-all`, `sudo Defaults`, modprobe blacklists, journald `Storage=persistent`, cron/at whitelist, umask defaults, etc.), the `fix` step addresses them.
 
## Backwards compatibility
 
- No schema changes.
- All modified fields (`command`, `sudo`, `requires_command`, `requires_file`, `expected_op`, `distro`, `fix`) were already used elsewhere in the file — no new keys introduced.
- Runtime file-detection commands (`[ -f x ] || y`) are plain POSIX sh, no bash-isms.
- Every rewritten check still returns the same verdict on the previously-covered distros; the only behavioural difference is that checks which previously *errored* on a specific distro now either pass, fail cleanly, or skip with a neutral `missing-command` state.