### PR TITLE
operating_system/linux: re-sequence the guide by application order and fix unpassable checks in ruleset.yaml

### DIFF
--- a/operating_system/linux/ERNW_Hardening_Linux.md
+++ b/operating_system/linux/ERNW_Hardening_Linux.md
@@ -6,154 +6,224 @@ title: Hardening Guide
 - [Introduction](#introduction)
   - [Scope \& Application](#scope--application)
   - [How to Read and Use This Document](#how-to-read-and-use-this-document)
-- [Authentication \& Identity Management](#authentication--identity-management)
+  - [Automated Auditing with `hardener`](#automated-auditing-with-hardener)
+          - [Obtaining and Building](#obtaining-and-building)
+          - [Audit, Fix and Rollback](#audit-fix-and-rollback)
+- [Phase 0: Before You Begin](#phase-0-before-you-begin)
+  - [How This Guide Is Sequenced](#how-this-guide-is-sequenced)
+  - [Before You Start](#before-you-start)
+  - [The Session Safety Protocol](#the-session-safety-protocol)
+- [Phase 1: Firmware, Disk Layout and Boot Chain](#phase-1-firmware-disk-layout-and-boot-chain)
+  - [Secure BIOS/UEFI Settings](#secure-biosuefi-settings)
+    - [BIOS/UEFI Administrator Password](#biosuefi-administrator-password)
+    - [Secure Boot Order](#secure-boot-order)
+    - [Enable Secure Boot](#enable-secure-boot)
+    - [Disable Unused Hardware](#disable-unused-hardware)
+  - [Partitioning and Mount Options](#partitioning-and-mount-options)
+    - [Target Layout](#target-layout)
+    - [Where These Options Break Things](#where-these-options-break-things)
+          - [`noexec` on `/tmp` is mandatory, but has known breakage](#noexec-on-tmp-is-mandatory-but-has-known-breakage)
+          - [`noexec` on `/home` MUST NOT be set](#noexec-on-home-must-not-be-set)
+          - [`noexec` on `/var` MUST NOT be set](#noexec-on-var-must-not-be-set)
+    - [How Much Does a Separate `/home` Buy You?](#how-much-does-a-separate-home-buy-you)
+    - [The Mount Options](#the-mount-options)
+    - [Reference `/etc/fstab`](#reference-etcfstab)
+          - [Distribution and `systemd` Specifics](#distribution-and-systemd-specifics)
+    - [Verification: the Expected End State](#verification-the-expected-end-state)
+    - [Applying Changes](#applying-changes)
+    - [Encryption (LUKS)](#encryption-luks)
+          - [Setting up a LUKS Partition](#setting-up-a-luks-partition)
+          - [Automated Unlocking via `/etc/crypttab`](#automated-unlocking-via-etccrypttab)
+          - [Swap Encryption](#swap-encryption)
+    - [Additional Filesystem Hardening](#additional-filesystem-hardening)
+  - [Secure GRUB Bootloader with a Password](#secure-grub-bootloader-with-a-password)
+    - [Password Protection Strategy](#password-protection-strategy)
+    - [Implementation Steps](#implementation-steps)
+          - [Generate the Hash](#generate-the-hash)
+        - [Configure the Users](#configure-the-users)
+    - [Finalizing the Configuration](#finalizing-the-configuration)
+  - [UEFI Secure Boot Verification](#uefi-secure-boot-verification)
+    - [Verification of Secure Boot Status](#verification-of-secure-boot-status)
+    - [Verification of User Mode](#verification-of-user-mode)
+    - [Kernel Module Signature Enforcement](#kernel-module-signature-enforcement)
+- [Phase 2: Base System Integrity](#phase-2-base-system-integrity)
+  - [Verify Package Integrity](#verify-package-integrity)
+    - [Verification by Distribution](#verification-by-distribution)
+          - [Debian and Ubuntu (`debsums`)](#debian-and-ubuntu-debsums)
+          - [RHEL, Fedora, and openSUSE (`rpm`)](#rhel-fedora-and-opensuse-rpm)
+          - [Arch Linux (`pacman`)](#arch-linux-pacman)
+    - [Interpreting Discrepancies](#interpreting-discrepancies)
+    - [Proactive Monitoring with AIDE](#proactive-monitoring-with-aide)
+  - [CPU Microcode Updates](#cpu-microcode-updates)
+    - [Installation of Microcode Packages](#installation-of-microcode-packages)
+    - [Microcode Loading and Verification](#microcode-loading-and-verification)
+    - [Vulnerability Mitigation Status](#vulnerability-mitigation-status)
+  - [Kernel Command Line Hardening](#kernel-command-line-hardening)
+    - [Memory Protection Rationale](#memory-protection-rationale)
+    - [Prevent Initramfs Debug Shell Access](#prevent-initramfs-debug-shell-access)
+          - [Configuration by Distribution Family](#configuration-by-distribution-family)
+          - [Implementation](#implementation)
+          - [Example Modification (Debian/Ubuntu)](#example-modification-debianubuntu)
+          - [Example Modification (RHEL/Fedora)](#example-modification-rhelfedora)
+          - [Runtime Verification](#runtime-verification)
+  - [Protecting Single User Mode](#protecting-single-user-mode)
+    - [Authentication Requirement](#authentication-requirement)
+    - [Configuration for Systemd (Modern Systems)](#configuration-for-systemd-modern-systems)
+          - [Manual Remediation](#manual-remediation)
+    - [Operational Impact](#operational-impact)
+  - [Disable Ctrl-Alt-Del Reboot Sequence](#disable-ctrl-alt-del-reboot-sequence)
+    - [Hardening with `systemd`](#hardening-with-systemd)
+    - [Verification](#verification)
+- [Phase 3: Establish Administrative Access](#phase-3-establish-administrative-access)
   - [Harden Administrative Accounts](#harden-administrative-accounts)
     - [Verifying that only One Admin Account Is Present](#verifying-that-only-one-admin-account-is-present)
     - [Restrict `su` Command Access](#restrict-su-command-access)
-  - [Check that All Passwords Are Shadowed](#check-that-all-passwords-are-shadowed)
-    - [Verify Password Shadowing](#verify-password-shadowing)
-  - [Use Strong Hashing Algorithm](#use-strong-hashing-algorithm)
-    - [Verify Hashing Algorithm](#verify-hashing-algorithm)
-  - [Password Policy](#password-policy)
-    - [Password Complexity (`pam_pwquality.so`)](#password-complexity-pam_pwqualityso)
-    - [Password History (`pam_pwhistory.so`)](#password-history-pam_pwhistoryso)
-    - [Strong Hashing Algorithm (`pam_unix.so`)](#strong-hashing-algorithm-pam_unixso)
-  - [Account Lockout (Faillock)](#account-lockout-faillock)
-    - [Account Lockout Policy Parameters](#account-lockout-policy-parameters)
-    - [Configuration in `/etc/pam.d/common-auth`](#configuration-in-etcpamdcommon-auth)
-  - [Password \& Account Aging](#password--account-aging)
-  - [Restricting Direct Root Login](#restricting-direct-root-login)
-    - [Configuring PAM for Secure TTYs](#configuring-pam-for-secure-ttys)
-    - [Restricting the Secure TTY List](#restricting-the-secure-tty-list)
   - [Harden Sudo Usage and Logging](#harden-sudo-usage-and-logging)
     - [Enforcing Pseudo-Terminal Use](#enforcing-pseudo-terminal-use)
     - [Configure Dedicated Sudo Logging](#configure-dedicated-sudo-logging)
     - [Limiting Password Cache Timeout](#limiting-password-cache-timeout)
     - [Restricting Su Usage](#restricting-su-usage)
-  - [Session and Screen Lock Hardening](#session-and-screen-lock-hardening)
-    - [Shell Session Timeouts (CLI)](#shell-session-timeouts-cli)
-    - [Graphical Screen Lock (GUI)](#graphical-screen-lock-gui)
-    - [Summary of Controls](#summary-of-controls)
+  - [Check that All Passwords Are Shadowed](#check-that-all-passwords-are-shadowed)
+    - [Verify Password Shadowing](#verify-password-shadowing)
+      - [Remediation](#remediation)
+- [Phase 4: Authentication and Password Policy](#phase-4-authentication-and-password-policy)
+  - [Use Strong Hashing Algorithm](#use-strong-hashing-algorithm)
+    - [Verify Hashing Algorithm](#verify-hashing-algorithm)
+  - [Password Policy](#password-policy)
+          - [Which File Holds the Password Stack](#which-file-holds-the-password-stack)
+    - [Password Complexity (`pam_pwquality.so`)](#password-complexity-pam_pwqualityso)
+    - [Password History (`pam_pwhistory.so`)](#password-history-pam_pwhistoryso)
+          - [The Password History File](#the-password-history-file)
+          - [Verification](#verification-1)
+    - [Strong Hashing Algorithm (`pam_unix.so`)](#strong-hashing-algorithm-pam_unixso)
+    - [The Complete Password Stack](#the-complete-password-stack)
+          - [Debian and Ubuntu (`/etc/pam.d/common-password`)](#debian-and-ubuntu-etcpamdcommon-password)
+          - [RHEL, Rocky, AlmaLinux and Fedora (via the `authselect` profile)](#rhel-rocky-almalinux-and-fedora-via-the-authselect-profile)
+          - [Testing the Stack Without Locking Yourself Out](#testing-the-stack-without-locking-yourself-out)
+  - [Password \& Account Aging](#password--account-aging)
+        - [Password Management Policy (`/etc/login.defs`)](#password-management-policy-etclogindefs)
+          - [Implementation](#implementation-1)
+          - [Verification](#verification-2)
+        - [Account Inactivity Defaults (`/etc/default/useradd`)](#account-inactivity-defaults-etcdefaultuseradd)
   - [User Authentication Hardening](#user-authentication-hardening)
     - [Strong Password Encryption](#strong-password-encryption)
     - [Minimum Password Length](#minimum-password-length)
     - [Use Sudo, Not Root](#use-sudo-not-root)
-- [Network Security \& Services](#network-security--services)
-  - [Verifying that Vulnerable and Not Required Software Is Disabled](#verifying-that-vulnerable-and-not-required-software-is-disabled)
-    - [Remove Insecure Legacy Protocols](#remove-insecure-legacy-protocols)
-    - [Restrict or Disable Potentially Necessary Services](#restrict-or-disable-potentially-necessary-services)
-    - [Essential Hardening Targets](#essential-hardening-targets)
-  - [Configuring and Hardening the Host Firewall](#configuring-and-hardening-the-host-firewall)
-    - [Configuring and Hardening the Host Firewall](#configuring-and-hardening-the-host-firewall-1)
-    - [Default Policy Hardening](#default-policy-hardening)
-    - [Reviewing and Removing Rules](#reviewing-and-removing-rules)
-  - [SSH Client Security](#ssh-client-security)
-    - [Eliminate the Server Attack Surface](#eliminate-the-server-attack-surface)
-    - [Maintain the Secure Client](#maintain-the-secure-client)
+  - [Account Lockout (Faillock)](#account-lockout-faillock)
+    - [Account Lockout Policy Parameters](#account-lockout-policy-parameters)
+    - [Configuration in `/etc/pam.d/common-auth`](#configuration-in-etcpamdcommon-auth)
+          - [Pre-authentication Stage (Tracking Failures):](#pre-authentication-stage-tracking-failures)
+          - [Authentication Failure Stage (Enforcing Lockout):](#authentication-failure-stage-enforcing-lockout)
+  - [Restricting Direct Root Login](#restricting-direct-root-login)
+- [Phase 5: File System Permissions and Isolation](#phase-5-file-system-permissions-and-isolation)
+  - [Enforce Restrictive Default Umask](#enforce-restrictive-default-umask)
+    - [Defining the Hardening Standards](#defining-the-hardening-standards)
+    - [Implementation in System Configuration](#implementation-in-system-configuration)
+          - [Global Account Defaults (`/etc/login.defs`)](#global-account-defaults-etclogindefs)
+          - [Shell Session Initialization (`/etc/profile.d/`)](#shell-session-initialization-etcprofiled)
+    - [Recommended Conditional Logic](#recommended-conditional-logic)
+          - [Verification](#verification-3)
+  - [Securing the Path Environment Variable](#securing-the-path-environment-variable)
+    - [Check for Globally Writable Paths](#check-for-globally-writable-paths)
+    - [Location of PATH Configuration](#location-of-path-configuration)
+  - [Hardening the Proc Filesystem](#hardening-the-proc-filesystem)
+  - [Audit and Restrict SUID/SGID Executables](#audit-and-restrict-suidsgid-executables)
+    - [Auditing SUID/SGID Files](#auditing-suidsgid-files)
+    - [Remediation Policy](#remediation-policy)
+          - [Remediation](#remediation-1)
+          - [Verification](#verification-4)
+  - [World Writable File and Directory Audit](#world-writable-file-and-directory-audit)
+    - [Auditing for World-Writable Files](#auditing-for-world-writable-files)
+          - [Remediation](#remediation-2)
+    - [System Paths vs. Home Directories](#system-paths-vs-home-directories)
+          - [System-Wide Paths (`/etc`, `/usr`, `/var`)](#system-wide-paths-etc-usr-var)
+          - [User Home Directories (`/home/user`)](#user-home-directories-homeuser)
+    - [Auditing for World-Writable Directories](#auditing-for-world-writable-directories)
+    - [Remediation and Best Practices](#remediation-and-best-practices)
+  - [Audit and Remediate Unowned and Ungrouped Files](#audit-and-remediate-unowned-and-ungrouped-files)
+    - [Auditing for Unowned Files](#auditing-for-unowned-files)
+    - [Auditing for Ungrouped Files](#auditing-for-ungrouped-files)
+          - [Remediation](#remediation-3)
+  - [Polyinstantiation of Temporary Directories](#polyinstantiation-of-temporary-directories)
+  - [Disable Core Dumps](#disable-core-dumps)
+    - [Configure User Limits (`/etc/security/limits.conf`)](#configure-user-limits-etcsecuritylimitsconf)
+          - [Verification](#verification-5)
+    - [Disable the `systemd-coredump` Service](#disable-the-systemd-coredump-service)
+          - [Remediation](#remediation-4)
+          - [Verification](#verification-6)
+- [Phase 6: Kernel and Network Stack Parameters](#phase-6-kernel-and-network-stack-parameters)
   - [Kernel Hardening](#kernel-hardening)
     - [Runtime Self-Protection](#runtime-self-protection)
     - [eBPF and Sandboxing](#ebpf-and-sandboxing)
     - [Network Stack Parameters](#network-stack-parameters)
     - [Restricting Kernel Modules](#restricting-kernel-modules)
     - [Cryptography (FIPS)](#cryptography-fips)
+          - [Implementation Procedure](#implementation-procedure)
+  - [IPv6 Attack Surface Reduction](#ipv6-attack-surface-reduction)
+    - [IPv6 Stack Hardening](#ipv6-stack-hardening)
+          - [Privacy Extensions (Temporary Addresses)](#privacy-extensions-temporary-addresses)
+          - [Disabling Source Routing and Redirects](#disabling-source-routing-and-redirects)
+          - [Router Advertisements (RA) Policy](#router-advertisements-ra-policy)
+          - [Implementation Procedure](#implementation-procedure-1)
+  - [Ensure Correct Loopback and Local Host Configuration](#ensure-correct-loopback-and-local-host-configuration)
+    - [Loopback Configuration](#loopback-configuration)
+    - [Local Hostname Resolution](#local-hostname-resolution)
+- [Phase 7: Services and Network Exposure](#phase-7-services-and-network-exposure)
+  - [Verifying that Vulnerable and Not Required Software Is Disabled](#verifying-that-vulnerable-and-not-required-software-is-disabled)
+    - [Remove Insecure Legacy Protocols](#remove-insecure-legacy-protocols)
+    - [Restrict or Disable Potentially Necessary Services](#restrict-or-disable-potentially-necessary-services)
+    - [Essential Hardening Targets](#essential-hardening-targets)
+  - [SSH Client Security](#ssh-client-security)
+    - [Eliminate the Server Attack Surface](#eliminate-the-server-attack-surface)
+    - [Maintain the Secure Client](#maintain-the-secure-client)
+  - [CUPS Security Hardening](#cups-security-hardening)
+    - [Disabling `cups-browsed`](#disabling-cups-browsed)
+          - [Service Status Verification](#service-status-verification)
+          - [Remediation Procedure](#remediation-procedure)
+  - [Disable or Remove Unnecessary File Sharing Services (Samba)](#disable-or-remove-unnecessary-file-sharing-services-samba)
+    - [Samba (SMB)](#samba-smb)
+          - [Check and Disable the Samba Service](#check-and-disable-the-samba-service)
+          - [Removing the Samba Package](#removing-the-samba-package)
+          - [For Debian/Ubuntu-based Systems](#for-debianubuntu-based-systems)
+          - [For RHEL/CentOS-based Systems](#for-rhelcentos-based-systems)
+          - [For SUSE/openSUSE-based Systems](#for-suseopensuse-based-systems)
+  - [DNS Resolver Security](#dns-resolver-security)
+    - [Restrict Local Resolver Exposure](#restrict-local-resolver-exposure)
+    - [Secure Transport and Validation](#secure-transport-and-validation)
+    - [Protect Resolver Configuration](#protect-resolver-configuration)
+          - [`/etc/resolv.conf` Is Usually a Symbolic Link](#etcresolvconf-is-usually-a-symbolic-link)
+          - [The Actual Control](#the-actual-control)
+  - [Configuring and Hardening the Host Firewall](#configuring-and-hardening-the-host-firewall)
+          - [Firewall Status and Activation](#firewall-status-and-activation)
+    - [Default Policy Hardening](#default-policy-hardening)
+    - [Reviewing and Removing Rules](#reviewing-and-removing-rules)
   - [Configure TCP Wrappers and Hosts Access](#configure-tcp-wrappers-and-hosts-access)
     - [Enforcement of Default Deny Policy](#enforcement-of-default-deny-policy)
     - [Configuring Explicit Allow Rules](#configuring-explicit-allow-rules)
     - [Setting Restrictive Permissions](#setting-restrictive-permissions)
     - [Verification of Service Linkage](#verification-of-service-linkage)
+- [Phase 8: Time, Logging and Auditing](#phase-8-time-logging-and-auditing)
   - [Secure Time Synchronization (Chrony)](#secure-time-synchronization-chrony)
     - [Necessity of Time Synchronization](#necessity-of-time-synchronization)
-  - [IPv6 Attack Surface Reduction](#ipv6-attack-surface-reduction)
-    - [IPv6 Stack Hardening](#ipv6-stack-hardening)
-  - [CUPS Security Hardening](#cups-security-hardening)
-    - [CUPS Security Hardening: Disabling `cups-browsed`](#cups-security-hardening-disabling-cups-browsed)
-  - [Disable or Remove Unnecessary File Sharing Services (Samba)](#disable-or-remove-unnecessary-file-sharing-services-samba)
-    - [Disable or Remove Unnecessary File Sharing Services: Samba (SMB)](#disable-or-remove-unnecessary-file-sharing-services-samba-smb)
-  - [DNS Resolver Security](#dns-resolver-security)
-    - [Restrict Local Resolver Exposure](#restrict-local-resolver-exposure)
-    - [Secure Transport and Validation](#secure-transport-and-validation)
-    - [Protect Resolver Configuration](#protect-resolver-configuration)
-  - [Ensure Correct Loopback and Local Host Configuration](#ensure-correct-loopback-and-local-host-configuration)
-    - [Loopback Configuration](#loopback-configuration)
-    - [2. Local Hostname Resolution](#2-local-hostname-resolution)
-- [System Boot \& Integrity Security](#system-boot--integrity-security)
-  - [Secure BIOS/UEFI Settings](#secure-biosuefi-settings)
-    - [BIOS/UEFI Administrator Password](#biosuefi-administrator-password)
-    - [Secure Boot Order](#secure-boot-order)
-    - [Enable Secure Boot](#enable-secure-boot)
-    - [Disable Unused Hardware](#disable-unused-hardware)
-  - [Secure GRUB Bootloader with a Password](#secure-grub-bootloader-with-a-password)
-    - [Password Protection Strategy](#password-protection-strategy)
-    - [Implementation Steps](#implementation-steps)
-    - [3. Finalizing the Configuration](#3-finalizing-the-configuration)
-  - [Kernel Command Line Hardening](#kernel-command-line-hardening)
-    - [Memory Protection Rationale](#memory-protection-rationale)
-    - [Prevent Initramfs Debug Shell Access](#prevent-initramfs-debug-shell-access)
-  - [UEFI Secure Boot Verification](#uefi-secure-boot-verification)
-    - [Verification of Secure Boot Status](#verification-of-secure-boot-status)
-    - [Verification of User Mode](#verification-of-user-mode)
-    - [Kernel Module Signature Enforcement](#kernel-module-signature-enforcement)
-  - [Verify Package Integrity](#verify-package-integrity)
-    - [Verification by Distribution](#verification-by-distribution)
-    - [Interpreting Discrepancies](#interpreting-discrepancies)
-    - [3. Proactive Monitoring with AIDE](#3-proactive-monitoring-with-aide)
-  - [Protecting Single User Mode](#protecting-single-user-mode)
-    - [Authentication Requirement](#authentication-requirement)
-    - [Configuration for Systemd (Modern Systems)](#configuration-for-systemd-modern-systems)
-    - [Operational Impact](#operational-impact)
-  - [Disable Ctrl-Alt-Del Reboot Sequence](#disable-ctrl-alt-del-reboot-sequence)
-    - [Hardening with `systemd`](#hardening-with-systemd)
-    - [Verification](#verification-1)
-  - [CPU Microcode Updates](#cpu-microcode-updates)
-    - [Installation of Microcode Packages](#installation-of-microcode-packages)
-    - [Microcode Loading and Verification](#microcode-loading-and-verification)
-    - [Vulnerability Mitigation Status](#vulnerability-mitigation-status)
-- [OS Hardening](#os-hardening)
-  - [Install and Configure USBGuard](#install-and-configure-usbguard)
-    - [Install and Configure USBGuard](#install-and-configure-usbguard-1)
-  - [Disable Core Dumps](#disable-core-dumps)
-    - [Disable Core Dumps](#disable-core-dumps-1)
-    - [Configure User Limits (`/etc/security/limits.conf`)](#configure-user-limits-etcsecuritylimitsconf)
-    - [Disable the `systemd-coredump` Service](#disable-the-systemd-coredump-service)
-  - [Securing the Path Environment Variable](#securing-the-path-environment-variable)
-    - [1. Check for Globally Writable Paths](#1-check-for-globally-writable-paths)
-    - [2. Location of PATH Configuration](#2-location-of-path-configuration)
-- [File System \& Permissions](#file-system--permissions)
-  - [Enforce Restrictive Default Umask](#enforce-restrictive-default-umask)
-    - [Defining the Hardening Standards](#defining-the-hardening-standards)
-    - [Implementation in System Configuration](#implementation-in-system-configuration)
-    - [Recommended Conditional Logic](#recommended-conditional-logic)
-  - [Partitioning and Mount Options](#partitioning-and-mount-options)
-    - [Partitioning Requirements](#partitioning-requirements)
-    - [Restrictive Mount Options](#restrictive-mount-options)
-    - [Encryption (LUKS)](#encryption-luks)
-    - [Polyinstantiated Directories](#polyinstantiated-directories)
-    - [Additional Filesystem Hardening](#additional-filesystem-hardening)
-  - [Enforcing Restrictive Mount Options](#enforcing-restrictive-mount-options)
-    - [Configuration for Temporary Filesystems](#configuration-for-temporary-filesystems)
-    - [Configuration for User Filesystems](#configuration-for-user-filesystems)
-    - [Applying Changes](#applying-changes)
-  - [Hardening the Proc Filesystem](#hardening-the-proc-filesystem)
-    - [Correctly Implementing Hidepid](#correctly-implementing-hidepid)
-    - [Applying Changes](#applying-changes-1)
-  - [Audit and Restrict SUID/SGID Executables](#audit-and-restrict-suidsgid-executables)
-    - [Auditing SUID/SGID Files](#auditing-suidsgid-files)
-    - [Remediation Policy](#remediation-policy)
-  - [World Writable File and Directory Audit](#world-writable-file-and-directory-audit)
-    - [Auditing for World-Writable Files](#auditing-for-world-writable-files)
-    - [System Paths vs. Home Directories](#system-paths-vs-home-directories)
-    - [Auditing for World-Writable Directories](#auditing-for-world-writable-directories)
-    - [Remediation and Best Practices](#remediation-and-best-practices)
-  - [Audit and Remediate Unowned and Ungrouped Files](#audit-and-remediate-unowned-and-ungrouped-files)
-    - [Auditing for Unowned Files](#auditing-for-unowned-files)
-    - [Auditing for Ungrouped Files](#auditing-for-ungrouped-files)
-  - [Polyinstantiation of Temporary Directories](#polyinstantiation-of-temporary-directories)
-    - [Configure Namespace Definitions](#configure-namespace-definitions)
-    - [Activate the PAM Module](#activate-the-pam-module)
-    - [Runtime Verification](#runtime-verification-1)
-- [Application Security \& Logging](#application-security--logging)
+          - [Enforce Least Privileges](#enforce-least-privileges)
+          - [Restrict Network Access](#restrict-network-access)
+          - [Implement Network Time Security (NTS)](#implement-network-time-security-nts)
+        - [Implementation Procedure](#implementation-procedure-2)
+  - [Systemd Journal Hardening and Integrity](#systemd-journal-hardening-and-integrity)
+    - [Enforcing Persistent Storage (Forensic Integrity)](#enforcing-persistent-storage-forensic-integrity)
+    - [Enabling Compression](#enabling-compression)
+    - [Log Forwarding to Traditional Syslog](#log-forwarding-to-traditional-syslog)
+    - [Protecting Persistent Log Directory](#protecting-persistent-log-directory)
+          - [Applying Changes](#applying-changes-1)
+  - [Syslog Daemon Hardening](#syslog-daemon-hardening)
+    - [Disable Network Listening (Attack Surface Reduction)](#disable-network-listening-attack-surface-reduction)
+    - [Restrict Log File Permissions (Confidentiality)](#restrict-log-file-permissions-confidentiality)
+    - [Secure Remote Forwarding](#secure-remote-forwarding)
   - [Audit Framework Installation and Setup](#audit-framework-installation-and-setup)
     - [Installation and Activation](#installation-and-activation)
+          - [Package Installation](#package-installation)
+          - [Service Enablement and Runtime Status](#service-enablement-and-runtime-status)
+          - [Verification of Audit Rules](#verification-of-audit-rules)
   - [Audit Rules for Identity and Privilege Escalation](#audit-rules-for-identity-and-privilege-escalation)
     - [Monitoring Critical Identity Files](#monitoring-critical-identity-files)
     - [Monitoring Privilege Escalation Binaries](#monitoring-privilege-escalation-binaries)
@@ -161,33 +231,53 @@ title: Hardening Guide
     - [Applying Rules](#applying-rules)
   - [Audit Rules for System Integrity and File Access](#audit-rules-for-system-integrity-and-file-access)
     - [Monitoring File Attribute Changes](#monitoring-file-attribute-changes)
+          - [Example Ruleset (Syscall Monitoring for Attribute Change)](#example-ruleset-syscall-monitoring-for-attribute-change)
     - [Monitoring File Deletion and Renaming](#monitoring-file-deletion-and-renaming)
+          - [Example Ruleset (Syscall Monitoring for Deletion)](#example-ruleset-syscall-monitoring-for-deletion)
     - [Monitoring Kernel Module Management](#monitoring-kernel-module-management)
+          - [Example Ruleset (Syscall Monitoring for Kernel Activity)](#example-ruleset-syscall-monitoring-for-kernel-activity)
     - [Applying Rules](#applying-rules-1)
   - [Enforcing Immutable Audit Configuration](#enforcing-immutable-audit-configuration)
+          - [Configuration](#configuration)
     - [Applying Immutable Mode](#applying-immutable-mode)
-  - [Syslog Daemon Hardening](#syslog-daemon-hardening)
-    - [Disable Network Listening (Attack Surface Reduction)](#disable-network-listening-attack-surface-reduction)
-    - [Restrict Log File Permissions (Confidentiality)](#restrict-log-file-permissions-confidentiality)
-    - [Secure Remote Forwarding](#secure-remote-forwarding)
-  - [Systemd Journal Hardening and Integrity](#systemd-journal-hardening-and-integrity)
-    - [Enforcing Persistent Storage (Forensic Integrity)](#enforcing-persistent-storage-forensic-integrity)
-    - [Enabling Compression](#enabling-compression)
-    - [Log Forwarding to Traditional Syslog](#log-forwarding-to-traditional-syslog)
-    - [Protecting Persistent Log Directory](#protecting-persistent-log-directory)
-  - [Cron Security](#cron-security)
-    - [`cron` And `at` Security](#cron-and-at-security)
-    - [Configuration for `cron`](#configuration-for-cron)
-    - [Configuration for `at`](#configuration-for-at)
+          - [Initial Setup](#initial-setup)
+          - [Runtime Verification](#runtime-verification-1)
+- [Phase 9: Runtime Confinement](#phase-9-runtime-confinement)
+  - [Mandatory Access Control (MAC) Implementation](#mandatory-access-control-mac-implementation)
+    - [SELinux (Security-Enhanced Linux)](#selinux-security-enhanced-linux)
+    - [AppArmor (Application Armor)](#apparmor-application-armor)
+    - [Mode Selection and Testing](#mode-selection-and-testing)
   - [Systemd Service Sandboxing and Resource Control](#systemd-service-sandboxing-and-resource-control)
     - [Protect System Directories (`ProtectSystem`)](#protect-system-directories-protectsystem)
     - [Protect User Home Directories (`ProtectHome`)](#protect-user-home-directories-protecthome)
     - [Isolate Temporary Storage (`PrivateTmp`)](#isolate-temporary-storage-privatetmp)
     - [Applying Overrides](#applying-overrides)
-  - [Mandatory Access Control (MAC) Implementation](#mandatory-access-control-mac-implementation)
-    - [SELinux (Security-Enhanced Linux)](#selinux-security-enhanced-linux)
-    - [AppArmor (Application Armor)](#apparmor-application-armor)
-    - [Mode Selection and Testing](#mode-selection-and-testing)
+          - [Example Content](#example-content)
+  - [Cron Security](#cron-security)
+    - [`cron` And `at` Security](#cron-and-at-security)
+          - [Implementing the Allow-List Principle](#implementing-the-allow-list-principle)
+    - [Configuration for `cron`](#configuration-for-cron)
+    - [Configuration for `at`](#configuration-for-at)
+  - [Session and Screen Lock Hardening](#session-and-screen-lock-hardening)
+    - [Graphical Screen Lock (GUI)](#graphical-screen-lock-gui)
+          - [System-wide Enforcement (GNOME)](#system-wide-enforcement-gnome)
+          - [Apply Changes](#apply-changes)
+    - [Summary of Controls](#summary-of-controls)
+          - [On Shell Session Timeouts (`TMOUT`)](#on-shell-session-timeouts-tmout)
+  - [Install and Configure USBGuard](#install-and-configure-usbguard)
+          - [Installation](#installation)
+          - [Policy Configuration (`rules.conf`)](#policy-configuration-rulesconf)
+          - [Generating an Initial Policy](#generating-an-initial-policy)
+          - [Enforcing the Block-by-Default Policy](#enforcing-the-block-by-default-policy)
+    - [Service Activation](#service-activation)
+          - [Start for Testing only](#start-for-testing-only)
+          - [Verification](#verification-7)
+          - [Enable at Boot (only After Successful Validation)](#enable-at-boot-only-after-successful-validation)
+          - [Applying Policy Changes](#applying-policy-changes)
+- [Phase 10: Verification and Maintenance](#phase-10-verification-and-maintenance)
+  - [Confirming the Result](#confirming-the-result)
+  - [Reboot and Re-verify](#reboot-and-re-verify)
+  - [Ongoing Maintenance](#ongoing-maintenance)
 
 
 # Introduction
@@ -234,896 +324,139 @@ The following formatting/semantics are used for the presentation of commands/cod
 
 > **Note:** This is an example Note.
 
-# Authentication & Identity Management
+## Automated Auditing with `hardener`
 
-This section describes essential authentication & identity management mechanisms on Linux.
+Every control in this guide is also expressed as a machine-readable check in the accompanying `ruleset.yaml`. The reference implementation that consumes this ruleset is **Hardener**:
 
-## Harden Administrative Accounts
+    https://github.com/mev0lent/hardener
 
-In this section, we enforce two *mandatory* controls to secure high-privilege accounts: ensuring a single root account and restricting the use of the `su` command.
+Hardener is a single, dependency-free binary that loads a ruleset, audits the system against it, applies the defined fixes, and rolls those fixes back from timestamped snapshots. It is the *only* tool this guide and the accompanying ruleset are written for. Rulesets in this format are not interchangeable with other hardening frameworks such as OpenSCAP, Lynis, CIS-CAT or Ansible hardening roles, and checks from those frameworks MUST NOT be copied into this ruleset without adapting them to the schema described below.
 
-### Verifying that only One Admin Account Is Present
+> **Note:** The project does not publish tagged releases. Always build from the current `main` branch, so that all ruleset schema fields used by this guide (`security_level`, `risk_level`, `expected_op`, labels and profile-based overrides) are supported.
 
-There MUST NOT be any user other than `root` with a User ID (`UID`) of `0`, as this grants full, unrestricted administrative privileges. The `/etc/passwd` file MUST be reviewed and, if necessary, edited.
+###### Obtaining and Building
 
-The following command can be used to verify this (i.e., that there is only one user with UID equal to `0`):
+Hardener is written in Go and requires Go 1.24 or newer:
 
-    > awk -F: '($3 == "0") {print}' /etc/passwd
-    root:x:0:0:root:/root:/bin/bash
+    > git clone https://github.com/mev0lent/hardener.git
+    > cd hardener
+    > GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o hardener-linux .
 
-> **Note:** This command MUST return only the `root` user entry. If more than one line is returned, manual action is required to investigate and remedy the unauthorized administrative account(s).
+###### Audit, Fix and Rollback
 
-### Restrict `su` Command Access
+    # Report compliance without changing anything
+    > ./hardener-linux audit --ruleset ruleset.yaml --all
 
-Restricting the use of `su` forces administrators to use `sudo`, which provides better control and logging of privilege escalation.
+    # Restrict the run to one tier or to specific sections
+    > ./hardener-linux audit --ruleset ruleset.yaml --all --security-level high
+    > ./hardener-linux audit --ruleset ruleset.yaml --all --label filesystem,network
 
-The system MUST activate the `pam_wheel.so` module in `/etc/pam.d/su` and specify the group used for system administration. This prevents non-privileged users from attempting to switch to `root`.
+    # Apply the fixes defined in the ruleset
+    > ./hardener-linux fix --ruleset ruleset.yaml --all
 
-To determine the correct group:
+    # Undo the most recent fix run
+    > ./hardener-linux rollback --latest
 
-- Use `getent` to check for the `wheel` group (common on RHEL/CentOS/Fedora) or the `sudo` group (common on Debian/Ubuntu):
+The `--security-level` flag maps directly to the `security_level` field of each check (`baseline`, `medium`, `high`); `--label` maps to the `labels` list of each check suite; and `--profile` (`server` or `client`) selects the role-based overrides. Several controls in this guide differ between a headless server and a workstation, and those differences are encoded as profile overrides rather than duplicated as separate checks.
 
-<!-- -->
+> **Note:** Checks whose `fix` value begins with `Manual action required:` are deliberately not automated, because an incorrect automated change would risk locking the administrator out or rendering the system unbootable. Hardener reports these as failures and prints the required manual step; it will not attempt them during a `fix` run.
 
-    > getent group wheel
-    > getent group sudo
+# Phase 0: Before You Begin
 
-Then you MUST modify `/etc/pam.d/su` to include the following line, replacing `<DESIRED_GROUP>` with the correct group name:
+Hardening changes authentication, boot and network behaviour. Applied in the wrong order, several of the controls in this guide will lock you out of the system you are hardening. This phase costs ten minutes and makes every later phase recoverable.
 
-    [...]
-    auth       required   pam_wheel.so group=<DESIRED_GROUP> 
-    [...]
+## How This Guide Is Sequenced
 
-Now only members of this designated group will be allowed to execute the `su` command.
+The controls in this guide are ordered by *when you apply them*, not by the category they
+belong to. Each phase assumes the previous ones are done:
 
-## Check that All Passwords Are Shadowed
-
-### Verify Password Shadowing
-
-Enforcing password shadowing is a *mandatory* control. Password hashes MUST be stored in the restricted-access `/etc/shadow` file, and MUST NOT be visible in the world-readable `/etc/passwd` file. When shadowing is enabled, the password field (the second field) in `/etc/passwd` contains an 'x'.
-
-The following command can be used to verify that all system passwords are correctly shadowed. This command searches for any entries in `/etc/passwd` where the password field does not contain an 'x' (or a '\*' or '!' which also indicate a disabled/locked account, but not a clear text hash):
-
-    > awk -F: '($2 != "x" && $2 != "*" && $2 != "!") {print}' /etc/passwd
-
-> **Note:** For compliance, this command MUST return NO output. If any entries are returned, it indicates a security vulnerability where password hashes may be readable by unauthorized users.
-
-#### Remediation
-
-If accounts with non-shadowed passwords are found, the `pwconv`[^2] utility is typically used to move the password information from etc/passwd to `/etc/shadow`.
-
-## Use Strong Hashing Algorithm
-
-Ensuring that Linux Pluggable Authentication Modules (`PAM`) uses a strong hashing mechanism is a mandatory control. This measure protects user password hashes from offline brute-force and dictionary attacks. The system MUST be configured to use a modern, strong hashing algorithm. `YESCRYPT` is the recommended choice, as it is the default in modern Linux distributions and provides memory-hard hashing, making offline attacks significantly more expensive. `SHA512` is also acceptable where `YESCRYPT` is not supported. This is controlled by setting the value of the `ENCRYPT_METHOD` parameter in the file `/etc/login.defs`.
-
-### Verify Hashing Algorithm
-
-The following command can be used to verify the configured hashing method for new users:
-
-    > grep ENCRYPT_METHOD /etc/login.defs
-    ENCRYPT_METHOD YESCRYPT
-
-> **Note:** If the value of this parameter is changed, users MUST change their password in order for the effect to take place. This is because this setting only applies when a password is created or changed, not to existing passwords.
-
-## Password Policy
-
-Enforcing a strong password policy is a *mandatory* control to protect user accounts from brute-force attacks and dictionary attacks. This policy is primarily enforced through the Pluggable Authentication Module (PAM) configuration file `/etc/pam.d/common-password`.
-
-### Password Complexity (`pam_pwquality.so`)
-
-The system MUST enforce strong complexity requirements using the `pam_pwquality.so` module. This ensures that new passwords meet a minimum standard for length and character diversity.
-
-The following configuration lines demonstrate the required parameters:
-
-| Parameter | Policy Set | Description |
+| Phase | Scope | Applied when |
 | :--- | :--- | :--- |
-| `minlen=16` | Minimum length | The password MUST be at least `16` characters long. |
-| `dcredit=-1` | Digit credit | The password MUST contain at least `1` digit. |
-| `ucredit=-1` | Uppercase credit | The password MUST contain at least `1` uppercase letter. |
-| `lcredit=-1` | Lowercase credit | The password MUST contain at least `1` lowercase letter. |
+| 0 | Preparation and lockout protection | Before touching anything |
+| 1 | Firmware, disk layout, encryption, boot chain | At install time |
+| 2 | Package integrity, microcode, boot-time bypasses | First boot |
+| 3 | Administrative access and `sudo` | Before any authentication change |
+| 4 | Passwords, PAM, lockout, root restrictions | After Phase 3 is verified |
+| 5 | File system permissions and isolation | Any time after Phase 1 |
+| 6 | Kernel and network stack parameters | Before Phase 7 |
+| 7 | Service removal and firewalling | After Phase 6 |
+| 8 | Time synchronisation, logging, auditing | After the system is configured |
+| 9 | MAC, sandboxing, session and device confinement | Last |
+| 10 | Verification and maintenance | Continuously |
 
-### Password History (`pam_pwhistory.so`)
+A control's *category* is still visible in the `labels` field of the corresponding check
+suite in `ruleset.yaml`, so an audit can still be scoped by topic:
 
-Password reuse makes systems vulnerable. The `pam_pwhistory.so` module MUST be configured to prevent users from cycling through their old passwords.
+    > ./hardener-linux audit --ruleset ruleset.yaml --all --label filesystem
 
-- `remember=5`: Prevents reuse of the last `5` passwords.
+The check suites in `ruleset.yaml` are stored in this same phase order, so
+`hardener fix --all` applies changes in the sequence described here rather than in an
+arbitrary one.
 
-- `enforce_for_root`: Applies the history check even to the `root` user, which is a *mandatory* hardening requirement.
+## Before You Start
 
-### Strong Hashing Algorithm (`pam_unix.so`)
+1.  **Take a full backup, and verify it restores.** Phase 1 involves partitioning and
+    encryption. A backup you have not tested is a hope, not a backup.
 
-The password hash stored in `/etc/shadow` MUST use a modern, slow, and computationally expensive algorithm to resist offline cracking. The `pam_unix.so` module is configured to use the `yescrypt` algorithm, which is the current state-of-the-art for many distributions.
+2.  **Have rescue media to hand.** A live USB of the same distribution lets you undo a bad
+    `/etc/fstab`, PAM or bootloader change. Without it, several controls in this guide are
+    one-way doors.
 
-The relevant line in `/etc/pam.d/common-password` MUST include the option:
+3.  **Know your rollback command.** Every fix applied by the tool is snapshotted:
 
-    password [success=2 default=ignore] pam_unix.so obscure use_authtok try_first_pass yescryp
-    (*LATEX@\lineBreakWithArrow@LATEX*)t
+        > ./hardener-linux rollback --latest
+        > ./hardener-linux rollback --files /etc/pam.d/common-password,/etc/fstab
 
-> **Note:** If the system is older and does not support `yescrypt`, `sha512` is the minimum acceptable hashing algorithm that MUST be used.
+4.  **Audit before you change anything**, and keep the output. It is your record of the
+    starting state:
 
-## Account Lockout (Faillock)
+        > ./hardener-linux audit --ruleset ruleset.yaml --all | tee ~/hardening-baseline.txt
 
-Implementing an Account Lockout policy is a *mandatory* control to effectively mitigate brute-force password guessing attacks against system accounts. This is configured within the `/etc/pam.d/common-auth` file using the `pam_faillock.so` module.
+5.  **Work one phase at a time**, and re-run the audit at the end of each. Applying all
+    phases in a single unattended run makes it impossible to tell which change broke what.
 
-The `pam_faillock.so` module MUST be configured twice: once in the pre-authentication stage (to reset the failure count upon success) and once in the authentication failure stage (to perform the lockout).
+## The Session Safety Protocol
 
-### Account Lockout Policy Parameters
+Several controls in Phases 3, 4, 7 and 9 can leave you unable to authenticate. The
+following protocol makes every one of them recoverable, and MUST be followed for any
+control marked with the lockout warning below.
 
-The following parameters MUST be applied to both `pam_faillock.so` lines:
+> **Warning (lockout risk):** This control can prevent you from logging in. Apply it under
 
-| Parameter | Policy Set | Effect |
-| :--- | :--- | :--- |
-| `deny=5` | Maximum attempts | MUST NOT allow more than `5` failed login attempts. |
-| `unlock_time=180` | Lock duration | Locks the account for `180` seconds (`3` minutes) after the maximum failure attempts are reached. |
-| `audit` | Logging | Logs all authentication failures to the system audit logs, improving traceability. |
-### Configuration in `/etc/pam.d/common-auth`
+> the session safety protocol.
 
-The required configuration lines MUST be present in `/etc/pam.d/common-auth` as follows:
+1.  **Open a privileged session and keep it open.** On a local machine, a root shell on a
+    second TTY (`Ctrl+Alt+F3`). Over the network, a second SSH connection:
 
-###### Pre-authentication Stage (Tracking Failures):
+        > sudo -i          # keep this shell open until step 4 succeeds
 
-    auth required pam_faillock.so preauth silent audit deny=5 unlock_time=180
+    A shell that already holds root does not re-authenticate, so it survives a broken PAM
+    stack, a locked account or a deleted `sudo` rule.
 
-###### Authentication Failure Stage (Enforcing Lockout):
+2.  **Apply the change** in a different session.
 
-    auth [default=die] pam_faillock.so authfail audit deny=5 unlock_time=180
+3.  **Test authentication in a third, new session**: a new SSH connection, a new TTY
+    login, or `su - <user>` from the privileged shell. Do not reuse the session that is
+    holding your safety net.
 
-> **Note:** The order of modules in the `/etc/pam.d/common-auth` file is critical. The `preauth` line MUST be placed near the top, and the `authfail` line MUST be placed after modules like `pam_unix.so` to ensure correct execution order.
+4.  **Only when step 3 succeeds**, close the privileged shell from step 1.
 
-## Password & Account Aging
+5.  **If step 3 fails**, use the still-open privileged shell to revert:
 
-Enforcing *Password and Account Aging* is a *mandatory* control that minimizes the risk associated with long-lived or abandoned user accounts. This policy is defined across two main configuration files: `/etc/login.defs` (for system-wide aging) and `/etc/default/useradd` (for new user defaults).
+        > ./hardener-linux rollback --latest
 
-##### Password Management Policy (`/etc/login.defs`)
+If you have already lost every session, boot the rescue media, mount the root filesystem
+and restore the affected file. For PAM changes, `/etc/pam.d/` is the place to look, and a
+distribution's stock files can be recovered from the package (`dpkg -i --force-confmiss`
+on Debian/Ubuntu, `rpm -Uvh --replacepkgs` on the RHEL family).
 
-Modern security standards from *NIST (SP 800-63B)*[^3] and *ENISA*[^4] no longer recommend periodic password rotation. Frequent forced changes lead to "password exhaustion," causing users to choose weaker, predictable patterns. Passwords should instead be long-lived and only changed if there is an indicator of compromise (IoC).
+> **Note:** Never test a PAM change by logging out. Logging out destroys the only session
+> that can repair the system. This is the single most common way administrators lock
+> themselves out during hardening.
 
-The parameters in `/etc/login.defs` must be adjusted to disable legacy rotation while maintaining a minimum age to prevent rapid cycling.
+# Phase 1: Firmware, Disk Layout and Boot Chain
 
-| Parameter | Policy Set | Effect |
-| :--- | :--- | :--- |
-| `PASS_MAX_DAYS` | `99999` | Disables periodic expiration (aligned with NIST/ENISA). |
-| `PASS_MIN_DAYS` | `1` | Prevents immediate changes, hindering users from cycling back to an old password instantly. |
-| `PASS_WARN_AGE` | `7` | Provides a 7-day warning only if an expiration is manually set. |
-
-###### Implementation
-
-Update `/etc/login.defs` to reflect these modern hardening standards:
-
-    # Set parameters to disable periodic rotation
-    > sed -i 's/^PASS_MAX_DAYS.*/PASS_MAX_DAYS   99999/' /etc/login.defs
-    > sed -i 's/^PASS_MIN_DAYS.*/PASS_MIN_DAYS   1/' /etc/login.defs
-    > sed -i 's/^PASS_WARN_AGE.*/PASS_WARN_AGE   7/' /etc/login.defs
-
-###### Verification
-
-Verify the configuration:
-
-    > grep -iE "PASS_MAX_DAYS|PASS_MIN_DAYS|PASS_WARN_AGE" /etc/login.defs
-
-> **Note:** Existing accounts will not be updated automatically. To apply these changes to an existing user, use the `chage` command:
-
-    chage --maxdays 99999 --mindays 1 <username>
-
-##### Account Inactivity Defaults (`/etc/default/useradd`)
-
-These settings apply to new accounts created using the `useradd` utility.
-
-| File | Parameter | Policy Set | Effect |
-| :--- | :--- | :--- | :--- |
-| `/etc/default/useradd` | `INACTIVE=30` | Inactive period | The account is permanently disabled `30` days after its password expires. Since periodic password expiration is disabled (`PASS_MAX_DAYS 99999`), this setting only takes effect for accounts where an expiration is explicitly set, for example, temporary or service accounts configured via `chage`. |
-| `/etc/default/useradd` | `EXPIRE=90` | Default expiration | *Optional:* This setting sets a default account expiration date (`90` days) from creation. This SHOULD only be used for temporary or service accounts, as it would cause all new user accounts to expire quickly. |
-
-## Restricting Direct Root Login
-
-Direct login as the `root` user removes the ability to audit which specific individual performed privileged actions. To ensure non-repudiation and accountability, administrators MUST log in as a standard user and escalate privileges using `sudo` or `su`.
-
-While SSH configurations typically handle network-based root restrictions, local terminal access is controlled via PAM and the `/etc/securetty` file.
-
-### Configuring PAM for Secure TTYs
-
-The system MUST check the `/etc/securetty` file during the login process. This is handled by the `pam_securetty.so` module.
-
-The file `/etc/pam.d/login` MUST contain the following configuration line:
-
-    auth required pam_securetty.so
-
-To verify that the module is active:
-
-    > grep "pam_securetty.so" /etc/pam.d/login
-    auth required pam_securetty.so
-
-### Restricting the Secure TTY List
-
-The `/etc/securetty` file lists the device names of the TTYs (terminals) where the root user is allowed to log in. If this file does not exist, most systems default to allowing root login on any TTY. If the file exists but is empty, root login is disabled on all devices.
-
-The `/etc/securetty` file MUST exist and SHOULD only contain the physical console and necessary serial terminals.
-
-> **Note:** On virtualized cloud systems (e.g., AWS, Azure, KVM), the "physical" console is often redirected to a serial port (e.g., `ttyS0` or `hvc0`). Removing these from `/etc/securetty` will block access via the provider's emergency web console.
-
-To safely configure this file for a standard physical server or desktop:
-
-    > echo -e "console\ntty1" | sudo tee /etc/securetty
-
-To check the current content of the file:
-
-    > cat /etc/securetty
-    console
-    tty1
-
-If the system requires serial console access (common for headless servers), ensure `ttyS0` (standard serial) or `hvc0` (Xen/virtualization) is included.
-
-## Harden Sudo Usage and Logging
-
-Administrative actions MUST be logged and attributable to a specific human user. The `sudo` utility is the preferred method for privilege escalation, as it logs the actual command executed, unlike the `su` utility, which merely logs a successful user switch.
-
-All controls outlined in this section MUST be implemented either directly in the `/etc/sudoers` file or, preferably, via a dedicated configuration file in the `/etc/sudoers.d/` directory.
-
-### Enforcing Pseudo-Terminal Use
-
-The `use_pty` option forces `sudo` to allocate a pseudo-terminal for the command being executed. This prevents certain input-reading attacks and, more importantly, ensures that the output is properly recorded in the `sudo` log file, regardless of the application run.
-
-The following MUST be added to a configuration file within `/etc/sudoers.d/`:
-
-    Defaults use_pty
-
-### Configure Dedicated Sudo Logging
-
-By default, `sudo` events are logged through the system logger (Syslog), often mixed with other logs in `/var/log/auth.log` or `/var/log/secure`. To facilitate easier security monitoring and auditing, a dedicated log file SHOULD be configured.
-
-    Defaults logfile=/var/log/sudo.log
-
-> **Note:** The log file `/var/log/sudo.log` must be created and protected with restrictive permissions (e.g., `chmod 0600 /var/log/sudo.log`) before the setting takes effect.
-
-### Limiting Password Cache Timeout
-
-When a user successfully authenticates with `sudo`, a timestamp is recorded, allowing subsequent `sudo` commands to run without requiring a password for a default duration (often 15 minutes). This duration MUST be reduced to minimize the window of opportunity if a logged-in session is left unattended.
-
-Setting the `timestamp_timeout` to 5 minutes is a common, balanced approach for high security environments:
-
-    Defaults timestamp_timeout=5
-
-### Restricting Su Usage
-
-Users who are granted administrative rights via `sudo` SHOULD NOT be allowed to use the `su` command to switch to the root account. The `su` utility is less auditable, as it does not log the individual commands executed after the switch.
-
-This restriction is best implemented by requiring the user to be a member of a specific group (e.g., `wheel` or `adm`) via PAM. The `pam_wheel.so` module can be used in the `/etc/pam.d/su` configuration to enforce this restriction.
-
-To verify the configuration is active for the `su` command, ensure the following line is present in `/etc/pam.d/su`:
-
-    auth required pam_wheel.so use_uid
-
-This configuration ensures that only users who are explicitly part of the allowed group can switch user identity using `su`.
-
-## Session and Screen Lock Hardening
-
-Unattended sessions, whether at a remote terminal or a local workstation, represent a significant security risk. To ensure a *locked-by-default* posture, both shell inactivity and graphical interface (GUI) timeouts MUST be enforced.
-
-### Shell Session Timeouts (CLI)
-
-The *TMOUT* variable automatically terminates inactive shell sessions. This is critical for servers where SSH or console sessions might be left open. For high-security environments, this MUST be set to *300 seconds (5 minutes)* and made read-only to prevent user override.
-
-###### Implementation
-
-Create a global configuration file:
-
-    > sudo tee /etc/profile.d/90-tmout.sh <<EOF
-    TMOUT=300
-    export TMOUT
-    readonly TMOUT
-    EOF
-
-### Graphical Screen Lock (GUI)
-
-On desktop systems, a shell timeout only closes the terminal window, leaving the rest of the desktop accessible. Therefore, the graphical session MUST be configured to lock automatically after 5 minutes of inactivity.
-
-###### System-wide Enforcement (GNOME)
-
-To prevent users from disabling the screen lock, create a *dconf* profile:
-
-1.  **Create the settings file:** `/etc/dconf/db/local.d/00-security-settings`
-
-<!-- -->
-
-    [org/gnome/desktop/session]
-    idle-delay=uint32 300
-
-    [org/gnome/desktop/screensaver]
-    lock-enabled=true
-
-1.  **Lock the settings (Prevent user override):** `/etc/dconf/db/local.d/locks/session`
-
-<!-- -->
-
-    /org/gnome/desktop/session/idle-delay
-    /org/gnome/desktop/screensaver/lock-enabled
-
-###### Apply Changes
-
-    > sudo dconf update
-
-### Summary of Controls
-
-| Scope | Mechanism | Target Value | Effect |
-| :--- | :--- | :--- | :--- |
-| *CLI* | *TMOUT* Variable | *300s* | Logs user out of the shell. |
-| *GUI* | *idle-delay* | *300s* | Activates screensaver/blank screen. |
-| *GUI* | *lock-enabled* | *true* | Requires password to resume session. |
-
-> **Note**: These settings do not interfere with long-running background tasks (e.g., compile jobs), only with interactive user engagement.
-
-## User Authentication Hardening
-
-Securing how you log in to your computer is the first line of defense against physical theft or unauthorized local access. By hardening the authentication settings, you ensure that your personal data remains protected even if someone gains access to the device.
-
-### Strong Password Encryption
-
-When you create a password, Linux does not store the plain text; it stores a *hash*. Older systems used weak methods that are easily cracked today. Modern systems MUST use a strong hashing algorithm. `YESCRYPT` is the recommended choice on modern distributions due to its memory-hard design, while `SHA512` remains acceptable where `YESCRYPT` is not supported.
-
-To verify your system is using the strongest method:
-
-    > grep '^ENCRYPT_METHOD' /etc/login.defs
-    # SHOULD display YESCRYPT, while SHA512 also remains acceptable
-
-### Minimum Password Length
-
-Short passwords are vulnerable to automated guessing. Enforcing a minimum length of *14 characters* ensures that you are using a passphrase that is computationally expensive to break.
-
-This is managed via the *pwquality* module. You can check your current requirement here:
-
-    > grep 'minlen' /etc/security/pwquality.conf
-
-### Use Sudo, Not Root
-
-On a secure personal Linux system, you should never log in directly as the *root* user. Instead, your personal user account should be granted administrative powers through *sudo*. Locking the *root* account prevents it from being targeted by malicious software or unauthorized users.
-
-- **Verification**: You can check if the root account is locked by running `passwd -S root`. A locked account will show an *L* in the status field.
-
-- **Safety**: Ensure your own user is in the *sudo* or *wheel* group before locking the root account to avoid losing administrative access.
-
-# Network Security & Services
-
-The following sections describe hardening settings in the category Authentication. The settings include an acceptable secure password policy and hardening of the authentication process itself.
-
-## Verifying that Vulnerable and Not Required Software Is Disabled
-
-Hardening a Linux system MUST include identifying and removing software that uses legacy protocols or exposes services to the network unnecessarily.
-
-### Remove Insecure Legacy Protocols
-
-Insecure protocols transmit credentials and data in clear text. These MUST be purged from the system. Verification is done by checking the `dpkg` status.
-
-    > dpkg -l | grep -E '^ii\s+(rsh-client|telnetd|vsftpd)'
-    (Output should be empty)
-
-- **R-Services (*rlogin*, *rsh*, *rcp*)**: These are fully replaced by the SSH suite.
-
-- **Telnet Server (*telnetd*)**: Transmits all data unencrypted.
-
-- **FTP Services (*vsftpd*, *pure-ftpd*)**: MUST be replaced with SFTP for secure file transfers.
-
-- **Network Protocol Blacklisting**: Protocols like DCCP or SCTP should be disabled if not needed. Check via:
-
-<!-- -->
-
-    > lsmod | grep -E 'dccp|sctp'
-
-### Restrict or Disable Potentially Necessary Services
-
-Some services provide functionality required locally. Instead of removal, these MUST be restricted to the loopback interface (`127.0.0.1`) to prevent network exposure.
-
-- **CUPS Printing (*cups*)**: If printing is required, the daemon MUST only listen on localhost. Verify the configuration:
-
-      > grep "^Listen" /etc/cups/cupsd.conf
-      Listen localhost:631
-
-- **Avahi Daemon (*avahi-daemon*)**: Provides Zero-configuration networking. It MUST be masked unless automatic discovery is strictly required.
-
-      > systemctl is-active avahi-daemon
-
-- **Bluetooth (*bluetooth*)**: On systems where Bluetooth is not used, the service MUST be masked to close the wireless attack vector.
-
-### Essential Hardening Targets
-
-The following services MUST be checked. If they are not essential, they MUST be disabled.
-
-- **TFTP Service (*tftpd*)**: Often used for network booting; MUST be removed if not in use.
-
-- **File Sharing (*nfs*, *samba*)**: These MUST be restricted via firewall rules to specific trusted subnets if required.
-
-- **Graphical Remote Desktop**: Remote access tools like VNC or RDP increase risk and MUST be disabled by default. Check for listening ports:
-
-      > ss -tulpn | grep -E '5900|3389'
-
-## Configuring and Hardening the Host Firewall
-
-### Configuring and Hardening the Host Firewall
-
-A host-based firewall is a *mandatory* component that implements *Defense-in-Depth* by blocking unwanted traffic from the Internet or local network. The specific firewall tool differs by distribution:
-
-- **Ubuntu / Debian / Arch**: *Uncomplicated Firewall (UFW)*, a frontend for `nftables`/`iptables`.
-
-- **Rocky / Fedora / RHEL / OpenSUSE**: *firewalld*, a zone-based dynamic firewall daemon.
-
-###### Firewall Status and Activation
-
-The firewall MUST be enabled and running to enforce security rules.
-
-On Ubuntu/Debian/Arch:
-
-    > sudo ufw status
-    Status: active
-
-    > sudo ufw enable        # if inactive
-
-On Rocky/Fedora/RHEL/OpenSUSE:
-
-    > sudo firewall-cmd --state
-    running
-
-    > sudo systemctl enable --now firewalld   # if not running
-
-### Default Policy Hardening
-
-A secure system follows the *Fail-Safe Default* principle: everything not explicitly permitted is denied.
-
-- **Incoming Traffic**: MUST be set to *deny*. This prevents other devices or attackers from initiating connections to your computer.
-
-  On Ubuntu/Debian/Arch (UFW):
-
-      sudo ufw default deny incoming
-
-  On Rocky/Fedora/RHEL/OpenSUSE (firewalld):
-
-      sudo firewall-cmd --set-default-zone=drop --permanent
-      sudo firewall-cmd --reload
-
-- **Outgoing Traffic**: For personal use, this is typically set to *allow* so that browsers, updates, and applications can function without manual intervention.
-
-  On Ubuntu/Debian/Arch (UFW):
-
-      sudo ufw default allow outgoing
-
-### Reviewing and Removing Rules
-
-Every open port is a potential entry point for attackers. If you have previously opened ports, review and remove them regularly.
-
-On Ubuntu/Debian/Arch (UFW):
-
-    > sudo ufw status numbered
-    Status: active
-
-    #     To                         Action      From
-    #[ 1] 80/tcp                     ALLOW IN    Anywhere
-
-    > sudo ufw delete 1     # remove rule no longer needed
-
-On Rocky/Fedora/RHEL/OpenSUSE (firewalld):
-
-    > sudo firewall-cmd --list-all
-    > sudo firewall-cmd --remove-service=http --permanent
-    > sudo firewall-cmd --reload
-
-- **Note**: Always maintain a minimal ruleset. If you do not explicitly host a service, your ruleset should ideally be empty, relying entirely on the *default deny* policy.
-
-## SSH Client Security
-
-Secure Shell (SSH) is a dual-purpose tool. While it is famous for managing servers, *end-users* primarily use it as a *client* to connect to other machines.
-
-### Eliminate the Server Attack Surface
-
-By default, many Linux distributions install or enable the SSH server (*sshd*). For a personal workstation, this is an unnecessary open door. If you do not need to log into your computer from another device, the server component MUST be removed.
-
-- **Verification**: Use the following command to check if the server is active. If it returns any result, the service is installed.
-
-      > dpkg -l | grep openssh-server
-
-- **Action**: Purging the package completely removes the configuration and the listening service, ensuring no one can attempt to brute-force your machine over the network (e.g., on Debian/Ubuntu: `sudo apt-get purge -y openssh-server`).
-
-### Maintain the Secure Client
-
-The SSH *client* is the part you use to initiate connections (e.g., `ssh user@remote-host`). This component is safe to keep and should be updated regularly to ensure the latest cryptographic patches are applied.
-
-- **Safe Usage**: Even with the server removed, your client remains functional. You can still use *SFTP* through file managers like *Nautilus* or *Dolphin* to transfer files to remote storage securely.
-
-## Kernel Hardening
-
-The Linux kernel is the core of your operating system. Hardening it involves configuring *runtime parameters* and *module restrictions* to reduce the available attack surface for both local and remote threats.
-
-### Runtime Self-Protection
-
-Modern kernels include features to make exploitation significantly more difficult. These are primarily managed via *sysctl*.
-
-- **ASLR (Address Space Layout Randomization)**: By setting `kernel.randomize_va_space=2`, the kernel randomizes where programs are loaded into memory, making it harder for attackers to predict target addresses for buffer overflows.
-
-- **Information Leak Prevention**: Restricting *dmesg* access (`kernel.dmesg_restrict=1`) and hiding kernel pointers (`kernel.kptr_restrict=2`) prevents unprivileged users from gathering data needed to bypass security features like *KASLR*.
-
-- **Ptrace Scope**: Setting `kernel.yama.ptrace_scope=1` ensures that a process can only be debugged by its parent, preventing malicious software from inspecting or injecting code into other running applications.
-
-- **Disabling Core Dumps**: Setting `fs.suid_dumpable=0` prevents sensitive memory from being written to disk during application crashes, which could otherwise be mined for credentials or secrets.
-
-### eBPF and Sandboxing
-
-While eBPF provides powerful tracing and networking capabilities, it also presents a significant attack surface if left open to unprivileged users.
-
-- **eBPF Restrictions**: Setting `kernel.unprivileged_bpf_disabled=1` prevents non-root users from loading eBPF programs. Additionally, `net.core.bpf_jit_harden=2` enables JIT hardening to mitigate JIT spraying attacks.
-
-- **User Namespace Cloning**: Setting `kernel.unprivileged_userns_clone=0` disables unprivileged user namespace creation. \> **Note:** This is a high-security setting that will break rootless containers (Podman), Flatpaks, and certain browser sandboxes.
-
-- **Filesystem Protection**: Setting `fs.protected_fifos=2` enables strict FIFO protection to prevent race conditions in named pipes, a common class of local privilege escalation.
-
-### Network Stack Parameters
-
-In a Zero Trust environment, the client must protect itself even from the local network. These settings harden the stack against local MitM attacks and spoofing, which are common when connecting to untrusted networks (e.g., public Wi-Fi or compromised internal segments). The network stack should be configured to prioritize security and integrity over legacy routing features.
-
-- **Anti-Spoofing**: Enabling the Reverse Path Filter (`net.ipv4.conf.all.rp_filter=1`) forces the kernel to verify that a packet arrived on the interface it should have, preventing IP spoofing attacks.
-
-- **Flooding Protection**: TCP SYN cookies (`net.ipv4.tcp_syncookies=1`) protect the system from *Denial of Service* attacks by validating connection requests without exhausting system resources.
-
-- **Disabling Routing & Redirects**: A personal workstation should not act as a router or accept external routing updates.
-
-  - `net.ipv4.ip_forward=0` (Disables forwarding)
-
-  - `net.ipv4.conf.all.send_redirects=0` (Disables sending ICMP redirects)
-
-  - `net.ipv4.conf.all.accept_redirects=0` (Disables accepting ICMP redirects)
-
-  - `net.ipv4.conf.all.accept_source_route=0` (Disables source-routed packets)
-
-- **ICMP Hardening**: Setting `net.ipv4.icmp_ignore_bogus_error_responses=1` ignores malformed ICMP error responses to reduce log noise and potential DoS vectors.
-
-### Restricting Kernel Modules
-
-Unnecessary kernel modules can contain vulnerabilities. If a feature is not used, its code should not be allowed to execute.
-
-- **USB Mass Storage**: For high-security environments, the `usb-storage` module can be blacklisted to prevent any USB drives from being mounted, stopping data exfiltration or malware entry.
-
-- **Legacy Protocols**: Protocols like `DCCP` (Datagram Congestion Control Protocol) and `SCTP` (Stream Control Transmission Protocol) are rarely used on desktops and should be blacklisted to close potential network entry points.
-
-### Cryptography (FIPS)
-
-For environments requiring high regulatory compliance, the OS should implement NIST FIPS-validated cryptography. This is typically audited via `/proc/sys/crypto/fips_enabled`. Enabling FIPS mode requires specific bootloader modifications and certified packages; it cannot be safely toggled via simple runtime commands as it may disable non-compliant SSH ciphers or other crypto primitives.
-
-###### Implementation Procedure
-
-To apply these settings persistently, create dedicated configuration files:
-
-    # General Kernel Hardening
-    > sudo tee /etc/sysctl.d/10-kernel-hardening.conf <<EOF
-    kernel.dmesg_restrict=1
-    kernel.randomize_va_space=2
-    fs.suid_dumpable=0
-    kernel.yama.ptrace_scope=1
-    kernel.kptr_restrict=2
-    kernel.unprivileged_bpf_disabled=1
-    net.core.bpf_jit_harden=2
-    kernel.unprivileged_userns_clone=0
-    fs.protected_fifos=2
-    EOF
-
-    # Network Hardening
-    >sudo tee /etc/sysctl.d/90-network-hardening.conf <<EOF
-    net.ipv4.tcp_syncookies=1
-    net.ipv4.conf.all.rp_filter=1
-    net.ipv4.conf.all.accept_redirects=0
-    net.ipv4.conf.all.accept_source_route=0
-    net.ipv4.icmp_ignore_bogus_error_responses=1
-    net.ipv4.ip_forward=0
-    net.ipv4.conf.all.send_redirects=0
-    EOF
-
-    # Module Blacklisting
-    > sudo tee /etc/modprobe.d/blacklist-unnecessary.conf <<EOF
-    install usb-storage /bin/true
-    blacklist dccp
-    blacklist sctp
-    EOF
-
-    # Apply sysctl changes immediately
-    > sudo sysctl -p /etc/sysctl.d/10-kernel-hardening.conf
-    > sudo sysctl -p /etc/sysctl.d/90-network-hardening.conf
-
-## Configure TCP Wrappers and Hosts Access
-
-TCP Wrappers provide a host-based access control system for services compiled against the `libwrap.so` library. While most modern access control is handled by dedicated host firewalls (e.g., UFW/nftables), TCP Wrappers remain relevant as a secondary, service-specific security layer for compatible services like `sshd`, `vsftpd`, and `telnetd`.
-
-### Enforcement of Default Deny Policy
-
-The security configuration MUST follow the principle of *Default Deny*. This is achieved by explicitly allowing only known good connections in `/etc/hosts.allow` and then denying everything else in `/etc/hosts.deny`.
-
-The `/etc/hosts.deny` file MUST contain a blanket rule to deny all access to all wrapped services:
-
-    ALL: ALL
-
-This ensures that any service linked against the library will deny a connection unless an explicit rule in `/etc/hosts.allow` overrides it.
-
-To implement this mandatory deny rule:
-
-    > echo 'ALL: ALL' | sudo tee /etc/hosts.deny
-
-### Configuring Explicit Allow Rules
-
-The `/etc/hosts.allow` file is where authorized services and hosts MUST be explicitly listed. The format is `daemon_list: client_list`.
-
-For example, to allow SSH access for all users coming from the local network (`192.168.1.0/24`) and a specific administrative host (`10.10.10.5`):
-
-    sshd: 192.168.1. 10.10.10.5
-
-> **Note:** You MUST define all necessary allow rules in `/etc/hosts.allow` before implementing the `ALL: ALL` deny rule in `/etc/hosts.deny`. Failure to do so will result in an immediate remote administrative lockout for the affected services. *Client systems* (workstations, endpoints) that do not require inbound SSH access MUST NOT add any `sshd` entry to `/etc/hosts.allow`. The blanket `ALL: ALL` deny rule in `/etc/hosts.deny` will then block all SSH connection attempts without any additional configuration.
-
-### Setting Restrictive Permissions
-
-The integrity of the access control files is paramount. They MUST be protected against unauthorized modification. Permissions SHOULD be set to 0644, ensuring only the root user can write to the files.
-
-To enforce the required permissions:
-
-    > sudo chmod 0644 /etc/hosts.allow
-    > sudo chmod 0644 /etc/hosts.deny
-
-### Verification of Service Linkage
-
-To determine if a specific service is utilizing TCP Wrappers, you can check if the executable is linked against the `libwrap.so` library using the `ldd` utility.
-
-Example check for the SSH daemon:
-
-    > ldd /usr/sbin/sshd | grep libwrap
-        libwrap.so.0 => /lib/x86_64-linux-gnu/libwrap.so.0 (0x00007f1f91b79000)
-
-If the `libwrap.so` library is present in the output, the service respects the rules defined in `/etc/hosts.allow` and `/etc/hosts.deny`.
-
-## Secure Time Synchronization (Chrony)
-
-Accurate time synchronization is mandatory for security. Reliable timestamps are critical for audit trails, log analysis, and authentication protocols such as Kerberos or TLS certificate validation. Time drift can render logs useless and break client authentication. Chrony is the preferred modern implementation over the legacy NTP daemon (ntpd).
-
-### Necessity of Time Synchronization
-
-The system must maintain time synchronized with an authoritative external source. A deviation from real-world time should not exceed one minute, although best practice is to limit drift to a few seconds to ensure logs from different systems remain correlated.
-
-###### Enforce Least Privileges
-
-The time synchronization daemon must run as a dedicated, unprivileged user (typically chrony or ntp). This limits the extent of damage if the daemon were to be compromised. Modern distributions configure this separation by default via the systemd unit file.
-
-To confirm the current user under which the daemon is running:
-
-    > ps -eo user,comm | grep chronyd
-
-The output must show the process owned by a non-root user.
-
-###### Restrict Network Access
-
-The command and control interface for Chrony (chronyc) allows administrators to monitor and adjust the daemon. This interface must be restricted to the loopback interface (`127.0.0.1` and `::1`) to prevent external users from querying or manipulating the service.
-
-The configuration file `/etc/chrony/chrony.conf` must contain:
-
-    bindcmdaddress 127.0.0.1
-    bindcmdaddress ::1
-
-If the system must act as a time server for an internal network, the `allow` directive should be used to restrict client access to that specific subnet only.
-
-###### Implement Network Time Security (NTS)
-
-Traditional NTP is vulnerable to Machine-in-the-Middle (MitM) attacks, where attackers can supply false time to the client. This can be used to bypass security features like certificate expiration checks. Network Time Security (NTS) is the modern standard and must be used whenever possible to cryptographically authenticate the time source using TLS.
-
-To use NTS, the configuration file requires specific servers and the nts option:
-
-    server nts.example.com iburst nts
-
-##### Implementation Procedure
-
-To apply the security configuration persistently, update the Chrony configuration and restart the service:
-
-    # Restrict command interface to localhost
-    > sudo tee -a /etc/chrony/chrony.conf <<EOF
-    bindcmdaddress 127.0.0.1
-    bindcmdaddress ::1
-    EOF
-
-    # Note: Ensure at least one NTS-capable server is added to /etc/chrony/chrony.conf
-    # Example: server nts.ntp.se iburst nts
-
-    # Apply changes
-    > sudo systemctl restart chronyd
-
-## IPv6 Attack Surface Reduction
-
-### IPv6 Stack Hardening
-
-As a foundational pillar of modern networking, IPv6 is essential for system interoperability and internal container orchestration. Rather than disabling the stack, which risks breaking local service discovery and modern application dependencies, security efforts must focus on hardening the protocol parameters to mitigate discovery and redirection attacks.
-
-###### Privacy Extensions (Temporary Addresses)
-
-By default, IPv6 addresses can expose a device's hardware (MAC) address via EUI-64 identifiers, allowing for global host tracking. We enforce *Privacy Extensions* ([RFC 4941](https://datatracker.ietf.org/doc/html/rfc4941)) to ensure the system generates short-lived, random addresses for all outgoing traffic.
-
-> **Note:** Setting `net.ipv6.conf.all.use_tempaddr = 2` ensures that temporary addresses are preferred over static, hardware-derived identifiers.
-
-###### Disabling Source Routing and Redirects
-
-Paralleling IPv4 security measures\[cite: 1\], the IPv6 stack must be configured to reject packets attempting to dictate the return path or manipulate local routing tables via ICMPv6 redirects.
-
-    # Prevent MitM via routing redirects
-    net.ipv6.conf.all.accept_redirects = 0
-    net.ipv6.conf.default.accept_redirects = 0
-
-    # Disable source routing (deprecated and vulnerable)
-    net.ipv6.conf.all.accept_source_route = 0
-    net.ipv6.conf.default.accept_source_route = 0
-
-###### Router Advertisements (RA) Policy
-
-While Router Advertisements are often required for dynamic connectivity (SLAAC), they present a significant attack vector if the kernel processes all flags unconditionally. We harden the RA handling to accept the prefix while ignoring potentially malicious flags that could be used for Denial of Service (DoS).
-
-> **Note**: In environments with static IP assignments, set `accept_ra = 0`. For workstations: maintain `accept_ra = 1` for connectivity but strictly enforce `accept_redirects = 0` to mitigate rogue router risks.
-
-###### Implementation Procedure
-
-To apply a comprehensive hardening profile immediately:
-
-    # Apply IPv6 Hardening
-    > sudo tee /etc/sysctl.d/90-ipv6-harden.conf <<EOF
-    # Privacy Extensions (RFC 4941)
-    net.ipv6.conf.all.use_tempaddr = 2
-    net.ipv6.conf.default.use_tempaddr = 2
-
-    # MitM & Spoofing Protection
-    net.ipv6.conf.all.accept_redirects = 0
-    net.ipv6.conf.default.accept_redirects = 0
-    net.ipv6.conf.all.accept_source_route = 0
-    net.ipv6.conf.default.accept_source_route = 0
-
-    # Router Advertisement Hardening
-    net.ipv6.conf.all.accept_ra_pinfo = 1
-    net.ipv6.conf.all.accept_ra_defrtr = 1
-    EOF
-
-    # Load the new parameters immediately
-    > sudo sysctl -p /etc/sysctl.d/90-ipv6-harden.conf
-
-## CUPS Security Hardening
-
-### CUPS Security Hardening: Disabling `cups-browsed`
-
-The Common UNIX Printing System (CUPS) is a modular printing system that allows a local system to act as a print server. The cups-browsed service is responsible for discovering remote CUPS printers and advertising local shared printers on the network, typically using protocols like DNS-SD (Bonjour/mDNS).
-
-While useful in certain network printing environments, running unnecessary network services significantly increases the attack surface of a system. The cups-browsed service, in particular, has been associated with critical remote code execution vulnerabilities (such as CVE-2024-47176). In these scenarios, attackers can potentially gain unauthorized access or control of the system by sending crafted packets to UDP port 631 and tricking the service into communicating with a malicious server.
-
-Unless the system explicitly requires the automatic discovery or browsing of network printers, the cups-browsed service must be disabled and stopped. For most server or hardened workstation environments where printing is either not required or managed manually, this service should not be running.
-
-###### Service Status Verification
-
-The following command can be used to check the status of the service:
-
-    > systemctl status cups-browsed
-
-The objective is for the output to show Active: inactive (dead) and for the service to be disabled. If the service is active or enabled, remediation is required.
-
-###### Remediation Procedure
-
-To stop the service immediately and prevent it from starting automatically at system boot, use the following command:
-
-    > sudo systemctl disable --now cups-browsed
-
-This command both stops the running service and removes the symlink that enables it at startup. For systems requiring even stricter enforcement, the service can be masked to prevent any other process from triggering it:
-
-    > sudo systemctl mask cups-browsed
-
-## Disable or Remove Unnecessary File Sharing Services (Samba)
-
-### Disable or Remove Unnecessary File Sharing Services: Samba (SMB)
-
-The Samba service provides *SMB/CIFS* file and print services for communication with Windows clients and other operating systems. On servers or workstations that do not explicitly need to act as a file or print server for Windows environments, the Samba service MUST be disabled or removed.
-
-File sharing services are a significant network attack vector and have historically been subject to severe vulnerabilities. Disabling or removing this service is a fundamental step in reducing the system's attack surface.
-
-The primary systemd units for the Samba service are typically `smbd` (the main daemon) and `nmbd` (NetBIOS name service).
-
-###### Check and Disable the Samba Service
-
-The following commands verify the status of the primary Samba service daemons:
-
-    > sudo systemctl status smbd
-    > sudo systemctl status nmbd
-
-The desired output for these commands is that the services are `Active: inactive (dead)` and disabled at boot.
-
-To ensure the services are stopped immediately and prevented from starting at boot, use the following command:
-
-    > sudo systemctl disable --now smbd nmbd
-
-###### Removing the Samba Package
-
-If Samba is not required for any function on the system, the packages SHOULD be completely removed. This is the most secure approach, as it eliminates the possibility of the service being inadvertently started or exploited.
-
-> **Note:** The automated hardener cannot typically determine if the removal of a package will break other system dependencies. Therefore, complete removal MUST be performed manually by the administrator after assessing the impact.
-
-Use the appropriate command for your distribution to completely remove the Samba package and its associated configuration files:
-
-###### For Debian/Ubuntu-based Systems
-
-    > sudo apt purge samba
-
-###### For RHEL/CentOS-based Systems
-
-    > sudo yum remove samba
-
-###### For SUSE/openSUSE-based Systems
-
-    > sudo zypper remove samba
-
-## DNS Resolver Security
-
-The Domain Name System (DNS) translates human-readable names into IP addresses. If this process is intercepted, attackers can redirect your browser to malicious websites. Protecting DNS integrity is vital for personal privacy and security.
-
-### Restrict Local Resolver Exposure
-
-Many Linux desktops run a local resolver like *systemd-resolved* or *Unbound*. These services MUST be restricted to the loopback interface (`127.0.0.1`). If they listen on all interfaces, they could be exploited by other devices on your local network.
-
-To verify your resolver is only listening locally:
-
-    > sudo ss -tuln | grep :53
-    tcp   LISTEN 0      4096      127.0.0.53%lo:53         0.0.0.0:*
-
-*The output should only show loopback addresses like 127.0.0.x or ::1.*
-
-### Secure Transport and Validation
-
-Standard DNS is unencrypted. To prevent Machine-in-the-Middle attacks, your system should use *DNS-over-TLS (DoT)* to encrypt queries or *DNSSEC* to cryptographically verify responses.
-
-- **Systemd-resolved**: This is the default on most modern desktops. You can enable encryption by editing */etc/systemd/resolved.conf*:
-
-      [Resolve]
-      DNSOverTLS=yes
-
-- **Validation**: Tools like *Unbound* can perform *DNSSEC* validation locally, ensuring that the data received has not been tampered with by an ISP or attackers.
-
-### Protect Resolver Configuration
-
-The file */etc/resolv.conf* tells your system which DNS servers to use. It MUST be protected against unauthorized changes to prevent malware from redirecting your traffic.
-
-Permissions MUST be set to *0644*:
-
-    > sudo chmod 0644 /etc/resolv.conf
-
-- **Note**: On modern systems, this file is often a *symbolic link* managed by *systemd-resolved*. In this case, you are protecting the link itself and the underlying configuration it points to.
-
-## Ensure Correct Loopback and Local Host Configuration
-
-The `/etc/hosts` file acts as a local address book for your computer. It allows the system to find itself and other local services before reaching out to the Internet. Proper configuration prevents apps from hanging while they wait for *DNS* responses that will never come.
-
-### Loopback Configuration
-
-The *loopback address* is a virtual interface used for internal communication. If this is missing or misconfigured, core system components and local applications (like your web browser or printing services) may fail to start.
-
-Both *IPv4* and *IPv6* versions MUST be defined:
-
-    127.0.0.1       localhost
-    ::1             localhost
-
-To verify these are present, use *grep* with a focus on the start of the line:
-
-    > grep -E '^\s*127\.0\.0\.1\s+localhost' /etc/hosts
-    127.0.0.1   localhost
-
-### 2. Local Hostname Resolution
-
-Your computer also needs to know its own name (*hostname*). On personal Linux desktops, it is standard practice to map the hostname to *127.0.1.1*. This keeps it separate from the generic *localhost* entry and avoids conflicts with some network services.
-
-First, check your current hostname:
-
-    > hostname
-    my-linux-laptop
-
-Then, ensure it appears in your *hosts* file mapped to a local address:
-
-    > grep "$(hostname)" /etc/hosts
-    127.0.1.1   my-linux-laptop
-
-> **Note**: Never map your hostname to an external *IP* address in this file if you move between networks (e.g., using a laptop on public Wi-Fi). Always use the *127.x.x.x* loopback range for your own hostname to ensure your traffic stays local.
-
-> **Modifying the File**: Because this is a system-critical file, you MUST use *sudo* to edit it. A simple typo can break your network connectivity entirely.
-
-# System Boot & Integrity Security
-
-This section covers the security of the boot process, including BIOS/UEFI protection, bootloader hardening, and the enforcement of a cryptographic chain of trust through Secure Boot.
+These controls are either impossible or expensive to retrofit. Full disk encryption and the partition layout in particular are install-time decisions: applying them later means repartitioning, which cannot be automated and cannot be rolled back. Do this phase first, ideally while installing the system.
 
 ## Secure BIOS/UEFI Settings
 
@@ -1162,9 +495,251 @@ To reduce the physical attack surface, disable any onboard components that are n
 
 - **Audio/Camera**: If the device is used in a high-security area, these can often be disabled at the firmware level for maximum protection.
 
+## Partitioning and Mount Options
+
+Partitioning and mount options provide a kernel-enforced defence-in-depth layer that cannot be bypassed by changing file permissions. Two distinct goals are served: *availability*, by preventing a full user or log directory from filling the root filesystem and halting the system, and *containment*, by removing the ability to execute binaries, honour SUID bits or interpret device nodes in the directories an attacker can most easily write to.
+
+> **Warning (data loss risk):** Repartitioning and `cryptsetup` operations destroy data, and an invalid `/etc/fstab` drops the system into an emergency shell on the next boot. Back up first and validate with `findmnt --verify` before rebooting.
+
+These are ordinary, fully functional Linux configurations. A separate `/home` is offered by most installers, and a `tmpfs`-backed `/tmp` is the systemd default on Fedora, RHEL 9, Arch and openSUSE. The controls in this section change *where* filesystems live and *which* flags they carry; they do not restrict what a legitimate user can do, provided the exceptions documented below are respected.
+
+The two halves of this section have very different costs.
+
+**Mount options are cheap.** They are applied by editing `/etc/fstab` and remounting, take
+effect immediately, and can be rolled back by the tool. Apply them on any system.
+
+**Separate partitions are not.** Retrofitting one means repartitioning, which cannot be
+automated, cannot be rolled back, and risks data loss. Treat the layout below as what to
+choose at install time.
+
+> **Note:** On an already-running client, apply the mount options and treat the partition
+> layout as advisory. This is why the partition checks for `/home` and `/var` are set to
+> `security_level: high` and are skipped by a default `baseline` audit run.
+
+> **Note:** Re-partitioning and modifying `cryptsetup` or `/etc/fstab` on a running system can lead to *permanent* data loss or a *non-bootable* system. Always take a full backup first, and keep a live/rescue medium available before the first reboot after an `/etc/fstab` change.
+
+### Target Layout
+
+The following table is the end state this section works towards. The *Options* column lists the options that MUST be added on top of `defaults`.
+
+| Mount point | Separate filesystem | Options to add | Rationale and functional impact |
+| :--- | :--- | :--- | :--- |
+| `/boot` | SHOULD | `nodev,nosuid,noexec` | Isolates kernel and bootloader. Safe: the bootloader reads this partition before the kernel enforces mount flags. |
+| `/boot/efi` (UEFI) | MUST (vfat) | `nodev,nosuid,noexec,umask=0077` | Firmware reads the ESP directly. `umask=0077` is required because vfat carries no UNIX permissions. |
+| `/home` | OPTIONAL (client), SHOULD (multi-user/server) | `nodev,nosuid` | Prevents user data from consuming system space and blocks SUID/device-node abuse in user-writable space. **`noexec` MUST NOT be set** (see below). |
+| `/var` | OPTIONAL (client), SHOULD (multi-user/server) | `nodev,nosuid` | Keeps application state, container images and spool data off the root filesystem. **`noexec` MUST NOT be set** (see below). |
+| `/var/log` | SHOULD | `nodev,nosuid,noexec` | A flooded log directory MUST NOT be able to halt the system. |
+| `/var/log/audit` | SHOULD | `nodev,nosuid,noexec` | `auditd` is configured to halt or suspend the system when its filesystem fills; isolating it contains that failure mode. |
+| `/var/tmp` | SHOULD | `nodev,nosuid,noexec` | World-writable, persistent across reboots. |
+| `/tmp` | MUST | `nodev,nosuid,noexec` | World-writable. The single most common staging location for dropped payloads. |
+| `/dev/shm` | MUST (tmpfs, always present) | `nodev,nosuid,noexec` | World-writable shared memory; used to stage fileless payloads. |
+
+Root (`/`), `/usr` and `/etc` remain on the root filesystem with `defaults`. Making `/usr` read-only is possible but is out of scope for this guide, as it requires distribution-specific update tooling.
+
+### Where These Options Break Things
+
+Three of the options above have real functional consequences on a client. Each is
+described separately below, with what to do instead.
+
+###### `noexec` on `/tmp` is mandatory, but has known breakage
+
+Some software builds and runs helper binaries in `/tmp`: DKMS module builds, vendor
+`.run` installers, `pip` building wheels from source, and Java applications that unpack
+native libraries.
+
+Where this happens, point the affected process at a private directory instead of removing
+`noexec`:
+
+    > export TMPDIR="$HOME/.cache/tmp" && mkdir -p "$TMPDIR"
+
+For a one-off system operation that genuinely needs execution from `/tmp`, remount for the
+duration and restore immediately:
+
+    > sudo mount -o remount,exec /tmp
+    > # ... perform the operation ...
+    > sudo mount -o remount,noexec /tmp
+
+###### `noexec` on `/home` MUST NOT be set
+
+Desktop and developer workflows execute code from the home directory: `~/.local/bin`,
+`pip`/`npm`/`cargo` user installations, Flatpak and AppImage bundles, version managers,
+IDE helpers and browser components.
+
+The protection gained is small in any case. A user who can write a binary can copy it
+somewhere executable, or invoke the interpreter directly with `sh ./script`, which
+`noexec` does not prevent.
+
+###### `noexec` on `/var` MUST NOT be set
+
+Package manager maintainer scripts (`/var/lib/dpkg/info/*.postinst`), `snapd` and
+container runtimes all execute from `/var`. Apply `noexec` to the `/var/log`,
+`/var/log/audit` and `/var/tmp` subtrees only, which have their own entries in the table
+above.
+
+### How Much Does a Separate `/home` Buy You?
+
+On a client, less than it appears, and it is worth being clear about why.
+
+The containment argument is that `nodev` and `nosuid` can then be applied to user-writable
+space. But creating a device node needs `CAP_MKNOD`, and setting a SUID bit needs root, so
+an ordinary user cannot produce either in the first place. These options are worth having,
+but they are defence in depth against an attacker who already has root.
+
+The availability argument, that user data cannot fill the root filesystem, is real. It is
+an operational concern rather than a security one, and on LVM or Btrfs a quota or
+subvolume limit addresses it without repartitioning.
+
+The practical guidance for a client is therefore:
+
+- Choose a separate `/home` at install time, where it costs nothing.
+- Do not repartition a working client to obtain one.
+- Where `/home` *is* separate, set `nodev,nosuid`, which are free.
+
+> **Note:** These options cannot be applied when `/home` sits on the root filesystem, as
+> they would have to be set on `/` itself. That would disable `sudo`, `su`, `passwd`,
+> `mount` and `ping`, all of which are SUID. The automated check therefore passes when
+> `/home` is not a separate filesystem: the control does not apply there.
+
+### The Mount Options
+
+| Option | Effect | Attack mitigated |
+| :--- | :--- | :--- |
+| `nodev` | The kernel does not interpret character or block special files on the filesystem. | Creation of a device node (e.g. a readable `/dev/sda` or `/dev/mem`) in a user-writable directory to bypass file permissions entirely. |
+| `nosuid` | The set-user-ID and set-group-ID bits are ignored for binaries on the filesystem. | Local privilege escalation via a SUID binary planted or copied into user-writable space. |
+| `noexec` | Direct execution of any file on the filesystem is refused. | Execution of dropped malware, compiled exploits and downloaded tooling from temporary directories. Does *not* block interpreted content invoked through an interpreter. |
+
+### Reference `/etc/fstab`
+
+The following is a complete, working example for a UEFI system using LVM on LUKS. Device paths and UUIDs are installation-specific; use `blkid` to obtain the correct values.
+
+    # <device>                <mount point>    <type>  <options>                              <dump> <pass>
+    /dev/mapper/vg0-root      /                ext4    defaults                                0      1
+    UUID=1234-ABCD            /boot/efi        vfat    defaults,nodev,nosuid,noexec,umask=0077 0      2
+    UUID=abcd1234-...         /boot            ext4    defaults,nodev,nosuid,noexec            0      2
+    /dev/mapper/vg0-home      /home            ext4    defaults,nodev,nosuid                   0      2
+    /dev/mapper/vg0-var       /var             ext4    defaults,nodev,nosuid                   0      2
+    /dev/mapper/vg0-varlog    /var/log         ext4    defaults,nodev,nosuid,noexec            0      2
+    /dev/mapper/vg0-varaudit  /var/log/audit   ext4    defaults,nodev,nosuid,noexec            0      2
+    /dev/mapper/vg0-vartmp    /var/tmp         ext4    defaults,nodev,nosuid,noexec            0      2
+    tmpfs                     /tmp             tmpfs   defaults,nodev,nosuid,noexec,size=2G    0      0
+    tmpfs                     /dev/shm         tmpfs   defaults,nodev,nosuid,noexec            0      0
+
+> **Note:** Order matters. `/var/log` must appear after `/var`, and `/var/log/audit` after `/var/log`, or the later mount will be shadowed. `systemd-fstab-generator` sorts by path depth automatically, but a manual `mount -a` does not.
+
+###### Distribution and `systemd` Specifics
+
+- **`/tmp` on `systemd` systems**: Fedora, RHEL 9, Rocky, Arch and openSUSE mount `/tmp`
+  as `tmpfs` through the built-in `tmp.mount` unit rather than through `/etc/fstab`.
+  Debian and Ubuntu leave `/tmp` on the root filesystem by default.
+
+  An `/etc/fstab` entry always takes precedence over `tmp.mount`, so the entry above is
+  the portable way to enforce the options everywhere. Overriding the unit is equivalent:
+
+      > sudo systemctl enable --now tmp.mount
+      > sudo systemctl edit tmp.mount
+      # [Mount]
+      # Options=mode=1777,strictatime,nosuid,nodev,noexec,size=2G
+
+- **`/dev/shm`**: mounted by `systemd` very early, before `/etc/fstab` is processed, and therefore **always** present but **not** hardened by default on most distributions. An explicit `/etc/fstab` entry causes it to be remounted with the correct options during boot; this is the supported approach and is what the automated check verifies.
+
+- **`/boot` on Btrfs-based layouts** (openSUSE, Fedora Silverblue): `/boot` may be a subvolume rather than a separate device. Options are set per subvolume in the same way.
+
+### Verification: the Expected End State
+
+Once the layout is in place, `findmnt` MUST show every hardened mount point carrying its options. This is the single command that confirms the end state:
+
+    > findmnt -o TARGET,SOURCE,FSTYPE,OPTIONS \
+        / /boot /boot/efi /home /var /var/log /var/log/audit /var/tmp /tmp /dev/shm
+
+    TARGET         SOURCE                   FSTYPE OPTIONS
+    /              /dev/mapper/vg0-root     ext4   rw,relatime
+    /boot          /dev/sda2                ext4   rw,nosuid,nodev,noexec,relatime
+    /boot/efi      /dev/sda1                vfat   rw,nosuid,nodev,noexec,relatime,umask=0077
+    /home          /dev/mapper/vg0-home     ext4   rw,nosuid,nodev,relatime
+    /var           /dev/mapper/vg0-var      ext4   rw,nosuid,nodev,relatime
+    /var/log       /dev/mapper/vg0-varlog   ext4   rw,nosuid,nodev,noexec,relatime
+    /var/log/audit /dev/mapper/vg0-varaudit ext4   rw,nosuid,nodev,noexec,relatime
+    /var/tmp       /dev/mapper/vg0-vartmp   ext4   rw,nosuid,nodev,noexec,relatime
+    /tmp           tmpfs                    tmpfs  rw,nosuid,nodev,noexec,size=2097152k
+    /dev/shm       tmpfs                    tmpfs  rw,nosuid,nodev,noexec
+
+A mount point that is absent from this output is not a separate filesystem, and a line missing `nosuid`, `nodev` or `noexec` is a finding.
+
+> **Note:** Use `findmnt -k` (kernel view) rather than parsing `/etc/fstab` when auditing. A correct `/etc/fstab` entry that has not been applied yet is not a hardened system, and the automated checks in the ruleset therefore query the kernel.
+
+### Applying Changes
+
+After editing `/etc/fstab`, validate the file *before* rebooting. A syntax error or a stale UUID leaves the system in the emergency shell:
+
+    > sudo findmnt --verify --verbose
+    > sudo systemctl daemon-reload
+
+Then apply the new options to the already-mounted filesystems without a reboot:
+
+    > sudo mount -o remount /tmp
+    > sudo mount -o remount /home
+    > sudo mount -o remount /var/log
+    > sudo mount -o remount /dev/shm
+
+> **Note:** `mount -o remount` re-reads the options from `/etc/fstab` for that mount point. It can add `nosuid`, `nodev` and `noexec` on a live system, but it cannot move a directory onto a new filesystem; creating a separate `/home` or `/var` requires repartitioning and a reboot.
+
+### Encryption (LUKS)
+
+For portable devices, **Full Disk Encryption (FDE)** is the standard for protecting data-at-rest. LUKS (Linux Unified Key Setup) provides a standardised header and multi-slot key management.
+
+###### Setting up a LUKS Partition
+
+1.  **Initialize the LUKS container**:
+
+<!-- -->
+
+    # WARNING: This wipes all data on the target partition
+    > cryptsetup luksFormat /dev/sdXn
+
+1.  **Map the device**:
+
+<!-- -->
+
+    > cryptsetup open /dev/sdXn crypt_data
+
+1.  **Format and mount**:
+
+<!-- -->
+
+    > mkfs.ext4 /dev/mapper/crypt_data
+    > mount /dev/mapper/crypt_data /mnt
+
+###### Automated Unlocking via `/etc/crypttab`
+
+To ensure the OS unlocks the device during boot, add it to `/etc/crypttab`:
+
+    # TARGET        SOURCE DEVICE       KEY FILE    OPTIONS
+    crypt_data      UUID=<your-uuid>    none        luks,discard
+
+###### Swap Encryption
+
+Swap space can leak sensitive information (e.g. encryption keys or passwords cached in RAM) to disk.
+
+    # /etc/crypttab entry for volatile (random key) swap
+    > swap /dev/sdXn /dev/urandom swap,cipher=aes-xts-plain64,size=256
+
+> **Note:** Using `/dev/urandom` for swap encryption breaks hibernation (Suspend-to-Disk), because the key is lost on every reboot. Systems that require hibernation MUST use a persistent key held inside the LUKS-encrypted root filesystem instead.
+
+### Additional Filesystem Hardening
+
+Beyond partitioning, specific permissions MUST be enforced:
+
+- **Sticky bits**: all world-writable directories MUST have the sticky bit set, so that users cannot delete files owned by others. This is audited in *World Writable File and Directory Audit*.
+
+- **Critical files**: permissions for `/etc/shadow` (`640`, `root:shadow`) and `/etc/passwd` (`644`, `root:root`) MUST be strictly maintained to prevent unauthorized credential access.
+
+- **Temporary directory isolation**: per-user instances of `/tmp` and `/var/tmp` are discussed in *Polyinstantiation of Temporary Directories*, which explains why they are not recommended on a client.
+
 ## Secure GRUB Bootloader with a Password
 
 The *Grand Unified Bootloader (GRUB)* is the first software loaded during startup. An unsecured GRUB menu allows anyone with physical access to modify kernel boot parameters, such as booting into *single-user mode* to gain full root access without a password.
+
+> **Warning (boot failure risk):** An incorrect bootloader password configuration can render the system unbootable. Verify the generated configuration before rebooting, and keep rescue media available.
 
 ### Password Protection Strategy
 
@@ -1193,7 +768,7 @@ Add the hash and the superuser name to `/etc/grub.d/40_custom` or a dedicated us
     set superusers="grub_admin"
     password_pbkdf2 grub_admin <YOUR_GENERATED_HASH>
 
-### 3. Finalizing the Configuration
+### Finalizing the Configuration
 
 After saving your changes, the GRUB configuration MUST be regenerated to write the new settings into the active boot file.
 
@@ -1202,6 +777,139 @@ After saving your changes, the GRUB configuration MUST be regenerated to write t
 *Note: On some distributions, the command is `sudo grub-mkconfig -o /boot/grub/grub.cfg`.*
 
 > **Note**: If you forget this password, you will be unable to access recovery modes or change boot settings without using external recovery media. Always keep a copy of this password in a secure physical location or password manager.
+
+## UEFI Secure Boot Verification
+
+UEFI Secure Boot is a mandatory security measure to prevent the execution of unauthorized or malicious code, such as bootkits and rootkits, during the pre-boot and boot processes. It relies on cryptographic signatures verified against keys stored in the system's firmware.
+
+### Verification of Secure Boot Status
+
+The primary check is ensuring Secure Boot is actively enforced by the UEFI firmware. This state is necessary to validate the signatures of the bootloader (GRUB) and the kernel.
+
+The `mokutil` utility is the preferred method for querying the status:
+
+    > mokutil --sb-state
+    SecureBoot is enabled
+
+The output MUST explicitly state SecureBoot is enabled.
+
+### Verification of User Mode
+
+Secure Boot operates in two primary modes:
+
+1.  **Setup Mode:** Allows modifications to the trusted key databases (DB, DBX, KEK). Enforcement is typically disabled or bypassed.
+
+2.  **User Mode:** Enforces the key databases, preventing any unauthorized code from running.
+
+The system MUST be in User Mode for the protection to be active. You can check the firmware mode using `bootctl`:
+
+    > bootctl status | grep 'Setup Mode'
+          Setup Mode: no
+
+### Kernel Module Signature Enforcement
+
+When Secure Boot is active, the running kernel SHOULD be configured to enforce signature checks on all kernel modules loaded after boot. This ensures that attackers cannot load a malicious rootkit module into kernel memory after the system has started.
+
+This check verifies the kernel's runtime setting:
+
+    > cat /proc/sys/kernel/module_sig_enforce
+    1
+
+The value MUST be 1 (enforced). If it is 0 while Secure Boot is enabled, the kernel or kernel headers may be incorrectly configured or incompatible.
+
+> **Note:** Secure Boot is a firmware setting. Any remediation to enable it requires physical access to the machine and configuration within the UEFI/BIOS settings. Ensure all components are signed (including third-party kernel modules like NVIDIA drivers) before enabling, or the system will fail to boot.
+
+# Phase 2: Base System Integrity
+
+With the machine booting from a trusted chain, confirm the software on it is the software the distribution shipped, and close the boot-time paths that bypass authentication. These controls are independent of each other and carry little risk.
+
+## Verify Package Integrity
+
+Regularly verifying the integrity of installed software is a critical detective control. This process compares current system files against the original metadata stored by the package manager to detect *corrupted*, *modified*, or *tampered* binaries.
+
+### Verification by Distribution
+
+Every major package manager provides tools to audit the current state of the system against its "known-good" baseline.
+
+###### Debian and Ubuntu (`debsums`)
+
+The `debsums` utility checks the MD5 checksums of files installed via `dpkg`.
+
+    # Only show modified configuration files
+    sudo debsums -c
+
+###### RHEL, Fedora, and openSUSE (`rpm`)
+
+The `rpm` verify command checks size, permissions, and signatures.
+
+    # Verify all packages, ignoring configuration files ('c')
+    sudo rpm -Va | grep -v '^..c'
+
+###### Arch Linux (`pacman`)
+
+For Arch Linux users, the native package manager can check for missing or modified files:
+
+    # Check all installed packages for missing files
+    pacman -Qk
+
+    # Verify file integrity against package checksums (requires pacutils)
+    paccheck --md5sum --quiet
+
+### Interpreting Discrepancies
+
+When a check fails, the tool provides codes indicating what changed. A *5* in RPM indicates a checksum mismatch, while an *S* indicates a change in file size.
+
+Modifications to configuration files (often marked with a *c*) are expected if you have customized your system. \> **Note**: Changes to binaries in `/bin`, `/sbin`, or `/usr/bin` that you did not explicitly update MUST be treated as a potential security breach.
+
+### Proactive Monitoring with AIDE
+
+While package manager checks are useful, they rely on the package manager's own database, which attackers might also modify. *AIDE* (Advanced Intrusion Detection Environment) provides an independent cryptographic baseline for your most sensitive files.
+
+- **Baseline**: After installation, run `sudo aideinit` to create the master database.
+
+- **Routine**: Regularly run `sudo aide --check` to find any unauthorized changes to the system core.
+
+- **Note**: Automated fixes for integrity failures are unsafe. If a binary is modified unexpectedly, treat the system as compromised and follow incident response procedures.
+
+## CPU Microcode Updates
+
+Microcode is low-level firmware that runs on the CPU itself. Because vulnerabilities like Spectre, Meltdown[^5], and MDS (Microarchitectural Data Sampling)[^6] exploit hardware design flaws, they often require patches to the CPU's microcode that cannot be fixed by software (kernel/OS) alone. Ensuring the latest microcode is loaded is a mandatory, non-negotiable step in modern system hardening.
+
+### Installation of Microcode Packages
+
+Microcode updates are typically provided by the OS vendor in packages specific to the CPU manufacturer. The relevant package MUST be installed on the system:
+
+- **Intel CPUs:** Install `intel-microcode` (Debian/Ubuntu) or `microcode_ctl` (RHEL/CentOS).
+
+- **AMD CPUs:** Install `amd64-microcode` (Debian/Ubuntu) or `microcode_ctl` (RHEL/CentOS).
+
+Example for Debian/Ubuntu:
+
+    > sudo apt install intel-microcode
+
+### Microcode Loading and Verification
+
+The OS microcode is loaded during the early boot process, usually by the bootloader (GRUB) or via the initial RAM disk (`initramfs`). This overrides the older microcode embedded in the system's UEFI/BIOS.
+
+To verify that the microcode has successfully updated, check the reported revision number in `/proc/cpuinfo`. A value greater than the BIOS default indicates a successful OS-level patch.
+
+    > grep 'microcode' /proc/cpuinfo
+    microcode   : 0x800113c
+
+The output MUST show a revision number (e.g., `0x800113c`) indicating an update.
+
+> **Note:** Installation of the microcode package requires a system reboot and sometimes a manual update of the `initramfs` (using `sudo update-initramfs -u` or equivalent) to ensure the microcode binary is included in the boot image.
+
+### Vulnerability Mitigation Status
+
+Modern Linux kernels expose the mitigation status for known hardware vulnerabilities in the `/sys/devices/system/cpu/vulnerabilities/` directory.
+
+The system MUST report a successful mitigation status for critical vulnerabilities like Spectre V2 (which relies heavily on microcode):
+
+    > cat /sys/devices/system/cpu/vulnerabilities/spectre_v2
+    Mitigation: eIBRS, IBPB, Retpolines
+
+The presence of specific mitigation techniques (e.g., `eIBRS`, `Retpolines`) confirms that the kernel and the updated microcode are working together to protect the processor.
 
 ## Kernel Command Line Hardening
 
@@ -1264,95 +972,6 @@ After rebooting, verify that the active kernel command line contains the desired
 
     > cat /proc/cmdline
     BOOT_IMAGE=... slab_nomerge vsyscall=none page_poison=1 pti=on panic=0
-
-## UEFI Secure Boot Verification
-
-UEFI Secure Boot is a mandatory security measure to prevent the execution of unauthorized or malicious code, such as bootkits and rootkits, during the pre-boot and boot processes. It relies on cryptographic signatures verified against keys stored in the system's firmware.
-
-### Verification of Secure Boot Status
-
-The primary check is ensuring Secure Boot is actively enforced by the UEFI firmware. This state is necessary to validate the signatures of the bootloader (GRUB) and the kernel.
-
-The `mokutil` utility is the preferred method for querying the status:
-
-    > mokutil --sb-state
-    SecureBoot is enabled
-
-The output MUST explicitly state SecureBoot is enabled.
-
-### Verification of User Mode
-
-Secure Boot operates in two primary modes:
-
-1.  **Setup Mode:** Allows modifications to the trusted key databases (DB, DBX, KEK). Enforcement is typically disabled or bypassed.
-
-2.  **User Mode:** Enforces the key databases, preventing any unauthorized code from running.
-
-The system MUST be in User Mode for the protection to be active. You can check the firmware mode using `bootctl`:
-
-    > bootctl status | grep 'Setup Mode'
-          Setup Mode: no
-
-### Kernel Module Signature Enforcement
-
-When Secure Boot is active, the running kernel SHOULD be configured to enforce signature checks on all kernel modules loaded after boot. This ensures that attackers cannot load a malicious rootkit module into kernel memory after the system has started.
-
-This check verifies the kernel's runtime setting:
-
-    > cat /proc/sys/kernel/module_sig_enforce
-    1
-
-The value MUST be 1 (enforced). If it is 0 while Secure Boot is enabled, the kernel or kernel headers may be incorrectly configured or incompatible.
-
-> **Note:** Secure Boot is a firmware setting. Any remediation to enable it requires physical access to the machine and configuration within the UEFI/BIOS settings. Ensure all components are signed (including third-party kernel modules like NVIDIA drivers) before enabling, or the system will fail to boot.
-
-## Verify Package Integrity
-
-Regularly verifying the integrity of installed software is a critical detective control. This process compares current system files against the original metadata stored by the package manager to detect *corrupted*, *modified*, or *tampered* binaries.
-
-### Verification by Distribution
-
-Every major package manager provides tools to audit the current state of the system against its "known-good" baseline.
-
-###### Debian and Ubuntu (`debsums`)
-
-The `debsums` utility checks the MD5 checksums of files installed via `dpkg`.
-
-    # Only show modified configuration files
-    sudo debsums -c
-
-###### RHEL, Fedora, and openSUSE (`rpm`)
-
-The `rpm` verify command checks size, permissions, and signatures.
-
-    # Verify all packages, ignoring configuration files ('c')
-    sudo rpm -Va | grep -v '^..c'
-
-###### Arch Linux (`pacman`)
-
-For Arch Linux users, the native package manager can check for missing or modified files:
-
-    # Check all installed packages for missing files
-    pacman -Qk
-
-    # Verify file integrity against package checksums (requires pacutils)
-    paccheck --md5sum --quiet
-
-### Interpreting Discrepancies
-
-When a check fails, the tool provides codes indicating what changed. A *5* in RPM indicates a checksum mismatch, while an *S* indicates a change in file size.
-
-Modifications to configuration files (often marked with a *c*) are expected if you have customized your system. \> **Note**: Changes to binaries in `/bin`, `/sbin`, or `/usr/bin` that you did not explicitly update MUST be treated as a potential security breach.
-
-### 3. Proactive Monitoring with AIDE
-
-While package manager checks are useful, they rely on the package manager's own database, which attackers might also modify. *AIDE* (Advanced Intrusion Detection Environment) provides an independent cryptographic baseline for your most sensitive files.
-
-- **Baseline**: After installation, run `sudo aideinit` to create the master database.
-
-- **Routine**: Regularly run `sudo aide --check` to find any unauthorized changes to the system core.
-
-- **Note**: Automated fixes for integrity failures are unsafe. If a binary is modified unexpectedly, treat the system as compromised and follow incident response procedures.
 
 ## Protecting Single User Mode
 
@@ -1423,200 +1042,418 @@ The output MUST confirm the target is loaded from `/dev/null`. If it points to a
 
 - **Note**: This setting only affects the physical keyboard sequence. It does not prevent an administrator from rebooting the system normally via the `reboot` command or the desktop environment's power menu.
 
-## CPU Microcode Updates
+# Phase 3: Establish Administrative Access
 
-Microcode is low-level firmware that runs on the CPU itself. Because vulnerabilities like Spectre, Meltdown[^5], and MDS (Microarchitectural Data Sampling)[^6] exploit hardware design flaws, they often require patches to the CPU's microcode that cannot be fixed by software (kernel/OS) alone. Ensuring the latest microcode is loaded is a mandatory, non-negotiable step in modern system hardening.
+Everything in Phase 4 restricts how you authenticate. Before changing any of it, make sure there is exactly one route to root, that it works, and that it is logged. Getting this phase right is what makes the next one safe: if `sudo` is working and audited here, a mistake in the PAM stack later is an inconvenience rather than a reinstall.
 
-### Installation of Microcode Packages
+## Harden Administrative Accounts
 
-Microcode updates are typically provided by the OS vendor in packages specific to the CPU manufacturer. The relevant package MUST be installed on the system:
+In this section, we enforce two *mandatory* controls to secure high-privilege accounts: ensuring a single root account and restricting the use of the `su` command.
 
-- **Intel CPUs:** Install `intel-microcode` (Debian/Ubuntu) or `microcode_ctl` (RHEL/CentOS).
+> **Warning (lockout risk):** This control can prevent you from logging in or from reaching the system over the network. Apply it under the *Session Safety Protocol* described in Phase 0.
 
-- **AMD CPUs:** Install `amd64-microcode` (Debian/Ubuntu) or `microcode_ctl` (RHEL/CentOS).
+### Verifying that only One Admin Account Is Present
 
-Example for Debian/Ubuntu:
+There MUST NOT be any user other than `root` with a User ID (`UID`) of `0`, as this grants full, unrestricted administrative privileges. The `/etc/passwd` file MUST be reviewed and, if necessary, edited.
 
-    > sudo apt install intel-microcode
+The following command can be used to verify this (i.e., that there is only one user with UID equal to `0`):
 
-### Microcode Loading and Verification
+    > awk -F: '($3 == "0") {print}' /etc/passwd
+    root:x:0:0:root:/root:/bin/bash
 
-The OS microcode is loaded during the early boot process, usually by the bootloader (GRUB) or via the initial RAM disk (`initramfs`). This overrides the older microcode embedded in the system's UEFI/BIOS.
+> **Note:** This command MUST return only the `root` user entry. If more than one line is returned, manual action is required to investigate and remedy the unauthorized administrative account(s).
 
-To verify that the microcode has successfully updated, check the reported revision number in `/proc/cpuinfo`. A value greater than the BIOS default indicates a successful OS-level patch.
+### Restrict `su` Command Access
 
-    > grep 'microcode' /proc/cpuinfo
-    microcode   : 0x800113c
+Restricting the use of `su` forces administrators to use `sudo`, which provides better control and logging of privilege escalation.
 
-The output MUST show a revision number (e.g., `0x800113c`) indicating an update.
+The system MUST activate the `pam_wheel.so` module in `/etc/pam.d/su` and specify the group used for system administration. This prevents non-privileged users from attempting to switch to `root`.
 
-> **Note:** Installation of the microcode package requires a system reboot and sometimes a manual update of the `initramfs` (using `sudo update-initramfs -u` or equivalent) to ensure the microcode binary is included in the boot image.
+To determine the correct group:
 
-### Vulnerability Mitigation Status
+- Use `getent` to check for the `wheel` group (common on RHEL/CentOS/Fedora) or the `sudo` group (common on Debian/Ubuntu):
 
-Modern Linux kernels expose the mitigation status for known hardware vulnerabilities in the `/sys/devices/system/cpu/vulnerabilities/` directory.
+<!-- -->
 
-The system MUST report a successful mitigation status for critical vulnerabilities like Spectre V2 (which relies heavily on microcode):
+    > getent group wheel
+    > getent group sudo
 
-    > cat /sys/devices/system/cpu/vulnerabilities/spectre_v2
-    Mitigation: eIBRS, IBPB, Retpolines
+Then you MUST modify `/etc/pam.d/su` to include the following line, replacing `<DESIRED_GROUP>` with the correct group name:
 
-The presence of specific mitigation techniques (e.g., `eIBRS`, `Retpolines`) confirms that the kernel and the updated microcode are working together to protect the processor.
+    [...]
+    auth       required   pam_wheel.so group=<DESIRED_GROUP> 
+    [...]
 
-# OS Hardening
+Now only members of this designated group will be allowed to execute the `su` command.
 
-The operating system layer represents the foundational attack surface of any Linux deployment. Beyond kernel and network parameter tuning, hardening at the OS level addresses physical attack vectors, process memory exposure, and privilege escalation paths that persist across reboots and user sessions. This section covers the restriction of USB mass storage devices via USBGuard, the suppression of core dump generation to prevent sensitive memory from being written to disk, and the enforcement of a clean, auditable PATH environment variable to eliminate binary hijacking opportunities.
+## Harden Sudo Usage and Logging
 
-## Install and Configure USBGuard
+Administrative actions MUST be logged and attributable to a specific human user. The `sudo` utility is the preferred method for privilege escalation, as it logs the actual command executed, unlike the `su` utility, which merely logs a successful user switch.
 
-### Install and Configure USBGuard
+All controls outlined in this section MUST be implemented either directly in the `/etc/sudoers` file or, preferably, via a dedicated configuration file in the `/etc/sudoers.d/` directory.
 
-USBGuard is a framework that allows you to control which USB devices are permitted to interact with your system. By default, Linux allows any plugged-in USB device to function, which creates risks such as BadUSB attacks, unauthorized data exfiltration, or the installation of malicious software.
+### Enforcing Pseudo-Terminal Use
 
-The USBGuard service MUST be installed, configured with a restrictive policy, and actively running to mitigate these physical security risks.
+The `use_pty` option forces `sudo` to allocate a pseudo-terminal for the command being executed. This prevents certain input-reading attacks and, more importantly, ensures that the output is properly recorded in the `sudo` log file, regardless of the application run.
 
-> **Note:** USBGuard MUST NOT be started without a valid policy in place. Starting the service without a configured ruleset can block input devices such as keyboard and mouse, rendering the system unresponsive. Always generate and verify a baseline policy before starting the service.
+The following MUST be added to a configuration file within `/etc/sudoers.d/`:
 
-###### Installation
+    Defaults use_pty
 
-The `usbguard` package MUST be installed using your distribution's package manager before proceeding.
+### Configure Dedicated Sudo Logging
 
-###### Policy Configuration (`rules.conf`)
+By default, `sudo` events are logged through the system logger (Syslog), often mixed with other logs in `/var/log/auth.log` or `/var/log/secure`. To facilitate easier security monitoring and auditing, a dedicated log file SHOULD be configured.
 
-A secure USBGuard policy follows the principle of least privilege, using a whitelist model: only explicitly authorized devices are allowed; all others are implicitly blocked.
+    Defaults logfile=/var/log/sudo.log
 
-A secure policy consists of two primary components:
+> **Note:** The log file `/var/log/sudo.log` must be created and protected with restrictive permissions (e.g., `chmod 0600 /var/log/sudo.log`) before the setting takes effect.
 
-1. *Whitelist Rules*: Rules for all devices that are known and necessary (e.g., internal USB hubs, keyboard, mouse).
-2. *Default Block Rule*: A final rule that ensures any unlisted or new devices are denied access.
+### Limiting Password Cache Timeout
 
-###### Generating an Initial Policy
+When a user successfully authenticates with `sudo`, a timestamp is recorded, allowing subsequent `sudo` commands to run without requiring a password for a default duration (often 15 minutes). This duration MUST be reduced to minimize the window of opportunity if a logged-in session is left unattended.
 
-The `usbguard` utility can generate a policy based on your currently connected devices. This is the recommended starting point for creating your personal whitelist. Ensure all essential peripherals (keyboard, mouse) are connected before running this command:
+Setting the `timestamp_timeout` to 5 minutes is a common, balanced approach for high security environments:
 
-```sh
-> sudo usbguard generate-policy > /etc/usbguard/rules.conf
-```
+    Defaults timestamp_timeout=5
 
-###### Enforcing the Block-by-Default Policy
+### Restricting Su Usage
 
-The last line of the `/etc/usbguard/rules.conf` file MUST be the generic block rule.
+Users who are granted administrative rights via `sudo` SHOULD NOT be allowed to use the `su` command to switch to the root account. The `su` utility is less auditable, as it does not log the individual commands executed after the switch.
 
-```text
-# The final rule MUST be a block rule to deny all other devices
-block
-```
+This restriction is best implemented by requiring the user to be a member of a specific group (e.g., `wheel` or `adm`) via PAM. The `pam_wheel.so` module can be used in the `/etc/pam.d/su` configuration to enforce this restriction.
 
-### Service Activation
+To verify the configuration is active for the `su` command, ensure the following line is present in `/etc/pam.d/su`:
 
-Once a valid policy is in place, the service MUST be started and tested before being enabled at boot.
+    auth required pam_wheel.so use_uid
 
-###### Start for Testing only
+This configuration ensures that only users who are explicitly part of the allowed group can switch user identity using `su`.
 
-```sh
-> sudo systemctl start usbguard
-```
+## Check that All Passwords Are Shadowed
 
-Verify that all required devices (keyboard, mouse, and other essential peripherals) continue to function correctly. If a device is blocked, update the policy accordingly before proceeding.
+### Verify Password Shadowing
+
+Enforcing password shadowing is a *mandatory* control. Password hashes MUST be stored in the restricted-access `/etc/shadow` file, and MUST NOT be visible in the world-readable `/etc/passwd` file. When shadowing is enabled, the password field (the second field) in `/etc/passwd` contains an 'x'.
+
+The following command can be used to verify that all system passwords are correctly shadowed. This command searches for any entries in `/etc/passwd` where the password field does not contain an 'x' (or a '\*' or '!' which also indicate a disabled/locked account, but not a clear text hash):
+
+    > awk -F: '($2 != "x" && $2 != "*" && $2 != "!") {print}' /etc/passwd
+
+> **Note:** For compliance, this command MUST return NO output. If any entries are returned, it indicates a security vulnerability where password hashes may be readable by unauthorized users.
+
+#### Remediation
+
+If accounts with non-shadowed passwords are found, the `pwconv`[^2] utility is typically used to move the password information from etc/passwd to `/etc/shadow`.
+
+# Phase 4: Authentication and Password Policy
+
+This is the phase that locks people out, and the order within it is deliberate: define the hashing algorithm before the policy that uses it, define the policy before you set passwords to match, and apply lockout and root restrictions only once you have confirmed a working login. Do not close your existing session at any point in this phase; see the session safety protocol in Phase 0.
+
+## Use Strong Hashing Algorithm
+
+Ensuring that Linux Pluggable Authentication Modules (`PAM`) uses a strong hashing mechanism is a mandatory control. This measure protects user password hashes from offline brute-force and dictionary attacks. The system MUST be configured to use a modern, strong hashing algorithm. `YESCRYPT` is the recommended choice, as it is the default in modern Linux distributions and provides memory-hard hashing, making offline attacks significantly more expensive. `SHA512` is also acceptable where `YESCRYPT` is not supported. This is controlled by setting the value of the `ENCRYPT_METHOD` parameter in the file `/etc/login.defs`.
+
+### Verify Hashing Algorithm
+
+The following command can be used to verify the configured hashing method for new users:
+
+    > grep ENCRYPT_METHOD /etc/login.defs
+    ENCRYPT_METHOD YESCRYPT
+
+> **Note:** If the value of this parameter is changed, users MUST change their password in order for the effect to take place. This is because this setting only applies when a password is created or changed, not to existing passwords.
+
+## Password Policy
+
+Enforcing a strong password policy is a *mandatory* control to protect user accounts from brute-force attacks and dictionary attacks. This policy is enforced through the *password* stack of the Pluggable Authentication Modules (PAM) subsystem.
+
+> **Warning (lockout risk):** This control can prevent you from logging in or from reaching the system over the network. Apply it under the *Session Safety Protocol* described in Phase 0.
+
+###### Which File Holds the Password Stack
+
+The three controls in this section (`pam_pwquality.so`, `pam_pwhistory.so` and `pam_unix.so`) are all configured in the *same* PAM password stack, but distributions place that stack in different files. Before applying any change, determine which file your system uses:
+
+| Distribution family | File(s) holding the password stack | Managed by |
+| :--- | :--- | :--- |
+| Debian, Ubuntu, openSUSE Leap | `/etc/pam.d/common-password` | `pam-auth-update` (Debian/Ubuntu), `pam-config` (SUSE) |
+| RHEL, Rocky, AlmaLinux, Fedora | `/etc/pam.d/system-auth` *and* `/etc/pam.d/password-auth` | `authselect` |
+| Arch, Manjaro | `/etc/pam.d/system-auth` | edited directly |
+
+    # Identify the correct file on the running system
+    > [ -f /etc/pam.d/system-auth ] && echo /etc/pam.d/system-auth || echo /etc/pam.d/common-password
+
+Two rules follow from that table, and ignoring either is how PAM edits get silently
+reverted:
+
+**On the RHEL family, never edit the files directly.** `/etc/pam.d/system-auth` and
+`/etc/pam.d/password-auth` are symbolic links into an `authselect` profile and are
+regenerated on every `authselect apply-changes`. Work through a custom profile:
+
+    > sudo authselect create-profile hardened --base-on sssd
+    > # edit the templates under /etc/authselect/custom/hardened/
+    > sudo authselect select custom/hardened
+
+Both files matter: `system-auth` covers local logins, `password-auth` covers remote ones
+(SSH, cockpit). A policy applied to only one of them is bypassable.
+
+**On Debian and Ubuntu, direct edits to `/etc/pam.d/common-password` are overwritten** by
+the next `pam-auth-update` run, which happens on package upgrades. Persist changes through
+a profile in `/usr/share/pam-configs/` instead.
+
+### Password Complexity (`pam_pwquality.so`)
+
+The system MUST enforce strong complexity requirements using the `pam_pwquality.so` module. This ensures that new passwords meet a minimum standard for length and character diversity.
+
+These parameters belong in `/etc/security/pwquality.conf` (or a drop-in under
+`/etc/security/pwquality.conf.d/`), *not* on the `pam_pwquality.so` line itself. Both
+work, but the configuration file is what the automated check reads, it survives
+`pam-auth-update` and `authselect` regeneration, and it keeps the PAM stack readable.
+
+| Parameter | Policy Set | Description |
+| :--- | :--- | :--- |
+| `minlen=16` | Minimum length | The password MUST be at least `16` characters long. |
+| `dcredit=-1` | Digit credit | The password MUST contain at least `1` digit. |
+| `ucredit=-1` | Uppercase credit | The password MUST contain at least `1` uppercase letter. |
+| `lcredit=-1` | Lowercase credit | The password MUST contain at least `1` lowercase letter. |
+
+Applied to `/etc/security/pwquality.conf`:
+
+    minlen = 16
+    dcredit = -1
+    ucredit = -1
+    lcredit = -1
+
+The module line itself then carries no policy arguments:
+
+    password requisite pam_pwquality.so retry=3
+
+### Password History (`pam_pwhistory.so`)
+
+Password reuse makes systems vulnerable. The `pam_pwhistory.so` module MUST be configured to prevent users from cycling through their old passwords. The module is added to the password stack identified above: `/etc/pam.d/common-password` on Debian/Ubuntu/openSUSE, `/etc/pam.d/system-auth` *and* `/etc/pam.d/password-auth` on the RHEL family, `/etc/pam.d/system-auth` on Arch.
+
+The required line is:
+
+    password required pam_pwhistory.so remember=5 enforce_for_root use_authtok
+
+- `remember=5`: Prevents reuse of the last `5` passwords. A higher value is acceptable; a lower value MUST NOT be used.
+
+- `enforce_for_root`: Applies the history check even to the `root` user, which is a *mandatory* hardening requirement. Without this option the module silently skips UID 0.
+
+- `use_authtok`: Reuses the password already collected by the preceding module instead of prompting again. This is required whenever `pam_pwhistory.so` is placed after `pam_pwquality.so`.
+
+> **Note:** Distributions differ in the control flag they ship. Debian/Ubuntu's `pam-auth-update` writes `password requisite pam_pwhistory.so`, while the RHEL family and Arch use `password required pam_pwhistory.so`. Both are acceptable and the automated check accepts either; what matters is that the module is present in the stack *before* `pam_unix.so`, since a password already accepted and hashed by `pam_unix.so` can no longer be rejected.
+
+###### The Password History File
+
+`pam_pwhistory.so` stores previous hashes in `/etc/security/opasswd`. This file contains password material and MUST be protected accordingly:
+
+    > sudo chown root:root /etc/security/opasswd
+    > sudo chmod 0600 /etc/security/opasswd
+
+If the file does not exist, the module creates it on the first password change; on some distributions it is absent until then, which is expected.
 
 ###### Verification
 
-```sh
-> sudo systemctl is-active usbguard
-```
+    # Debian / Ubuntu / openSUSE
+    > grep pam_pwhistory /etc/pam.d/common-password
 
-###### Enable at Boot (only After Successful Validation)
+    # RHEL / Rocky / AlmaLinux / Fedora / Arch
+    > grep pam_pwhistory /etc/pam.d/system-auth /etc/pam.d/password-auth
 
-```sh
-> sudo systemctl enable usbguard
-```
+### Strong Hashing Algorithm (`pam_unix.so`)
 
-###### Applying Policy Changes
+The password hash stored in `/etc/shadow` MUST use a modern, slow, and computationally expensive algorithm to resist offline cracking. The `pam_unix.so` module is configured to use the `yescrypt` algorithm, which is the current state-of-the-art for many distributions.
 
-After modifying the configuration at any point, you MUST reload the policy:
+The relevant `pam_unix.so` line in the password stack MUST include the algorithm option. On Debian/Ubuntu (`/etc/pam.d/common-password`):
 
-```sh
-> sudo usbguard set-policy apply
-```
+    password [success=2 default=ignore] pam_unix.so obscure use_authtok try_first_pass yescrypt
 
-## Disable Core Dumps
+On the RHEL family the equivalent line lives in the `authselect` profile behind `/etc/pam.d/system-auth` and `/etc/pam.d/password-auth`:
 
-### Disable Core Dumps
+    password sufficient pam_unix.so sha512 shadow use_authtok
 
-A core dump is a memory image file created by the operating system when a program terminates unexpectedly (crashes). While useful for developers and system administrators for debugging purposes, core dump files often contain sensitive data, including passwords, encryption keys, and proprietary information that was held in memory at the time of the crash. Storing these files on disk represents a significant data confidentiality risk.
+> **Note:** If the system does not support `yescrypt`, `sha512` is the minimum acceptable hashing algorithm that MUST be used. RHEL 9 and its derivatives do not ship `yescrypt` support in `libxcrypt` as configured by default, so `sha512` is the strongest option available there and the automated check accepts either value.
 
-To mitigate this risk, the system MUST be configured to prevent the creation of core dump files for all users and processes.
+### The Complete Password Stack
 
-### Configure User Limits (`/etc/security/limits.conf`)
+The three modules above are only effective in the right order. `pam_pwquality.so` and
+`pam_pwhistory.so` MUST both appear *before* `pam_unix.so`: once `pam_unix.so` has accepted
+and hashed a password, nothing later in the stack can reject it.
 
-The primary method for disabling core dumps for user processes is to set the hard limit for the core file size to zero (`0`) in the `/etc/security/limits.conf` file. This prevents unprivileged users from writing core dumps.
+The assembled stack looks like this.
 
-The following line MUST be added or verified to exist in `/etc/security/limits.conf`:
+###### Debian and Ubuntu (`/etc/pam.d/common-password`)
 
-    * hard core 0
+    password requisite                   pam_pwquality.so retry=3
+    password required                    pam_pwhistory.so remember=5 enforce_for_root use_authtok
+    password [success=2 default=ignore]  pam_unix.so obscure use_authtok try_first_pass yescrypt
+    password requisite                   pam_deny.so
+    password required                    pam_permit.so
 
-- The asterisk (`*`) applies this rule to all users.
+###### RHEL, Rocky, AlmaLinux and Fedora (via the `authselect` profile)
 
-- `hard` sets an enforced maximum value.
+    password requisite  pam_pwquality.so try_first_pass local_users_only
+    password required   pam_pwhistory.so remember=5 enforce_for_root use_authtok
+    password sufficient pam_unix.so sha512 shadow use_authtok
+    password required   pam_deny.so
 
-- `core 0` sets the maximum size of a core file to zero bytes.
+> **Warning (lockout risk):** Do not hand-edit the numeric jump in Debian's
+
+> `[success=2 default=ignore]`. It counts the modules to skip on success, so inserting or
+> removing a line after `pam_unix.so` silently breaks the stack. Add modules *before*
+> `pam_unix.so`, as shown, or let `pam-auth-update` regenerate the file.
+
+###### Testing the Stack Without Locking Yourself Out
+
+A broken password stack does not announce itself until someone changes a password, and by
+then it may also be refusing logins. Test it deliberately, under the *Session Safety
+Protocol* from Phase 0:
+
+1.  Keep a root shell open. An existing root shell does not re-authenticate.
+
+2.  From that shell, create a throwaway account and try to set a password on it:
+
+        > sudo useradd -m pamtest
+        > sudo passwd pamtest
+
+3.  Confirm the policy behaves as intended: a short password such as `abc` MUST be
+    rejected, and a compliant one MUST be accepted. An error such as
+    `Module is unknown` or `Authentication token manipulation error` means the stack is
+    broken, not that the password was bad.
+
+4.  Log in as that account in a *new* session to confirm authentication still works.
+
+5.  Remove the account, and only then close the root shell:
+
+        > sudo userdel -r pamtest
+
+## Password & Account Aging
+
+Enforcing *Password and Account Aging* is a *mandatory* control that minimizes the risk associated with long-lived or abandoned user accounts. This policy is defined across two main configuration files: `/etc/login.defs` (for system-wide aging) and `/etc/default/useradd` (for new user defaults).
+
+##### Password Management Policy (`/etc/login.defs`)
+
+Modern security standards from *NIST (SP 800-63B)*[^3] and *ENISA*[^4] no longer recommend periodic password rotation. Frequent forced changes lead to "password exhaustion," causing users to choose weaker, predictable patterns. Passwords should instead be long-lived and only changed if there is an indicator of compromise (IoC).
+
+The parameters in `/etc/login.defs` must be adjusted to disable legacy rotation while maintaining a minimum age to prevent rapid cycling.
+
+| Parameter | Policy Set | Effect |
+| :--- | :--- | :--- |
+| `PASS_MAX_DAYS` | `99999` | Disables periodic expiration (aligned with NIST/ENISA). |
+| `PASS_MIN_DAYS` | `1` | Prevents immediate changes, hindering users from cycling back to an old password instantly. |
+| `PASS_WARN_AGE` | `7` | Provides a 7-day warning only if an expiration is manually set. |
+
+###### Implementation
+
+Update `/etc/login.defs` to reflect these modern hardening standards:
+
+    # Set parameters to disable periodic rotation
+    > sed -i 's/^PASS_MAX_DAYS.*/PASS_MAX_DAYS   99999/' /etc/login.defs
+    > sed -i 's/^PASS_MIN_DAYS.*/PASS_MIN_DAYS   1/' /etc/login.defs
+    > sed -i 's/^PASS_WARN_AGE.*/PASS_WARN_AGE   7/' /etc/login.defs
 
 ###### Verification
 
-    > grep -E "^\*\s+hard\s+core\s+0$" /etc/security/limits.conf
-    * hard core 0
+Verify the configuration:
 
-### Disable the `systemd-coredump` Service
+    > grep -iE "PASS_MAX_DAYS|PASS_MIN_DAYS|PASS_WARN_AGE" /etc/login.defs
 
-Modern Linux distributions using `systemd` may use the `systemd-coredump` service to manage and store core dumps in the journal. To fully disable core dump creation, this service MUST be stopped, disabled, and masked to prevent it from being accidentally started by another service or administrator.
+> **Note:** Existing accounts will not be updated automatically. To apply these changes to an existing user, use the `chage` command:
 
-###### Remediation
+    chage --maxdays 99999 --mindays 1 <username>
 
-    > sudo systemctl stop systemd-coredump
-    > sudo systemctl disable systemd-coredump
-    > sudo systemctl mask systemd-coredump
+##### Account Inactivity Defaults (`/etc/default/useradd`)
 
-The `mask` command ensures that the service unit file cannot be started even if another service attempts to pull it as a dependency, providing the strongest form of disabling.
+These settings apply to new accounts created using the `useradd` utility.
 
-###### Verification
+| File | Parameter | Policy Set | Effect |
+| :--- | :--- | :--- | :--- |
+| `/etc/default/useradd` | `INACTIVE=30` | Inactive period | The account is permanently disabled `30` days after its password expires. Since periodic password expiration is disabled (`PASS_MAX_DAYS 99999`), this setting only takes effect for accounts where an expiration is explicitly set, for example, temporary or service accounts configured via `chage`. |
+| `/etc/default/useradd` | `EXPIRE=90` | Default expiration | *Optional:* This setting sets a default account expiration date (`90` days) from creation. This SHOULD only be used for temporary or service accounts, as it would cause all new user accounts to expire quickly. |
 
-    > sudo systemctl is-enabled systemd-coredump
-    masked
+## User Authentication Hardening
 
-## Securing the Path Environment Variable
+Securing how you log in to your computer is the first line of defense against physical theft or unauthorized local access. By hardening the authentication settings, you ensure that your personal data remains protected even if someone gains access to the device.
 
-The `PATH` environment variable lists the directories searched by the shell for executable commands. If a directory in the `PATH` is writable by non-privileged users (globally writable), it creates a severe vulnerability. Attackers can place a malicious executable with the same name as a common command, such as `ls` or `cd`, in that directory. When a privileged user executes the command, the trojan may run instead of the legitimate binary, leading to privilege escalation.
+> **Warning (lockout risk):** This control can prevent you from logging in or from reaching the system over the network. Apply it under the *Session Safety Protocol* described in Phase 0.
 
-The system MUST NOT include any globally writable directories in the default `PATH`.
+### Strong Password Encryption
 
-### 1. Check for Globally Writable Paths
+When you create a password, Linux does not store the plain text; it stores a *hash*. Older systems used weak methods that are easily cracked today. Modern systems MUST use a strong hashing algorithm. `YESCRYPT` is the recommended choice on modern distributions due to its memory-hard design, while `SHA512` remains acceptable where `YESCRYPT` is not supported.
 
-Standard system directories like `/bin`, `/usr/bin`, `/sbin`, and `/usr/sbin` MUST NOT be writable by anyone except the `root` user.
+To verify your system is using the strongest method:
 
-Run the following command to check common system directories for the world-writable bit (`/0002`):
+    > grep '^ENCRYPT_METHOD' /etc/login.defs
+    # SHOULD display YESCRYPT, while SHA512 also remains acceptable
 
-    > find /usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin -type d -perm /0002 2>
-    (*LATEX@\lineBreakWithArrow@LATEX*)/dev/null
+### Minimum Password Length
 
-The output MUST be empty. Any listed directory represents an immediate security risk and requires manual intervention.
+Short passwords are vulnerable to automated guessing. A minimum length of *14 characters* is the mandatory floor; *16* is recommended and is the value used in the Password Policy table above. Longer values are always acceptable; the automated check treats 14 as a minimum, not as an exact target, so a stricter local policy will not be reported as a failure.
 
-### 2. Location of PATH Configuration
+This is managed via the *pwquality* module. You can check your current requirement here:
 
-The `PATH` variable is usually defined in global shell configuration files. You should review these to ensure no insecure or relative paths (like `.`) are being added:
+    > grep -rh '^\s*minlen' /etc/security/pwquality.conf /etc/security/pwquality.conf.d/
+    minlen = 16
 
-- `/etc/profile`
+> **Note:** On the RHEL family, `/etc/security/pwquality.conf.d/` drop-ins override `/etc/security/pwquality.conf`, and the last definition read wins. Check both locations before concluding which value is in force.
 
-- `/etc/bash.bashrc`
+### Use Sudo, Not Root
 
-- Files within `/etc/profile.d/`
+On a secure personal Linux system, you should never log in directly as the *root* user. Instead, your personal user account should be granted administrative powers through *sudo*. Locking the *root* account prevents it from being targeted by malicious software or unauthorized users.
 
-- **Security Note**: Regardless of where the variable is set, the primary control is ensuring the *target directories* are not writable by untrusted users.
+- **Verification**: You can check if the root account is locked by running `passwd -S root`. A locked account will show an *L* in the status field.
 
-- **Manual Action**: If a directory is found to be writable, investigate the cause before changing permissions. Use `chmod o-w <directory>` to secure it once the risk is understood.
+- **Safety**: Ensure your own user is in the *sudo* or *wheel* group before locking the root account to avoid losing administrative access.
 
-# File System & Permissions
+## Account Lockout (Faillock)
 
-A misconfigured file system is one of the most reliable footholds for local privilege escalation. Overly permissive defaults, improperly mounted partitions, and world-writable or unowned files can each be leveraged to elevate privileges or persist malicious code across system updates. This section establishes baseline controls across the entire file system: enforcing a restrictive default `umask`, separating critical partitions, hardening mount options to restrict execution and device access, locking down the `/proc` virtual file system, auditing SUID/SGID binaries, identifying world-writable and unowned files, and isolating temporary directory namespaces through polyinstantiation.
+Implementing an Account Lockout policy is a *mandatory* control to effectively mitigate brute-force password guessing attacks against system accounts. This is configured within the `/etc/pam.d/common-auth` file using the `pam_faillock.so` module.
+
+> **Warning (lockout risk):** This control can prevent you from logging in or from reaching the system over the network. Apply it under the *Session Safety Protocol* described in Phase 0.
+
+The `pam_faillock.so` module MUST be configured twice: once in the pre-authentication stage (to reset the failure count upon success) and once in the authentication failure stage (to perform the lockout).
+
+### Account Lockout Policy Parameters
+
+The following parameters MUST be applied to both `pam_faillock.so` lines:
+
+| Parameter | Policy Set | Effect |
+| :--- | :--- | :--- |
+| `deny=5` | Maximum attempts | MUST NOT allow more than `5` failed login attempts. |
+| `unlock_time=180` | Lock duration | Locks the account for `180` seconds (`3` minutes) after the maximum failure attempts are reached. |
+| `audit` | Logging | Logs all authentication failures to the system audit logs, improving traceability. |
+### Configuration in `/etc/pam.d/common-auth`
+
+The required configuration lines MUST be present in `/etc/pam.d/common-auth` as follows:
+
+###### Pre-authentication Stage (Tracking Failures):
+
+    auth required pam_faillock.so preauth silent audit deny=5 unlock_time=180
+
+###### Authentication Failure Stage (Enforcing Lockout):
+
+    auth [default=die] pam_faillock.so authfail audit deny=5 unlock_time=180
+
+> **Note:** The order of modules in the `/etc/pam.d/common-auth` file is critical. The `preauth` line MUST be placed near the top, and the `authfail` line MUST be placed after modules like `pam_unix.so` to ensure correct execution order.
+
+## Restricting Direct Root Login
+
+Direct login as `root` removes the ability to attribute privileged actions to an individual.
+Administrators MUST log in as a standard user and escalate with `sudo`.
+
+On current distributions this is enforced by locking the `root` account (covered under
+*User Authentication Hardening*) and, for network access, by `PermitRootLogin no` in the
+SSH daemon configuration.
+
+> **Note:** Older baselines enforce this with `pam_securetty.so` and `/etc/securetty`. That
+> mechanism is obsolete and is deliberately not used here. `/etc/securetty` no longer ships
+> on current Debian and Ubuntu releases, and the RHEL family no longer references
+> `pam_securetty` in its login stack. Re-creating the file to satisfy an old benchmark risks
+> blocking console and serial console access, which on a machine with full disk encryption
+> can mean losing your only local recovery path.
+
+
+# Phase 5: File System Permissions and Isolation
+
+The disk layout was fixed in Phase 1; this phase governs what happens inside it. These controls are largely independent and safe to apply in any order, with the exception of the default `umask`, which should be set before you create further user accounts.
 
 ## Enforce Restrictive Default Umask
 
@@ -1632,203 +1469,121 @@ For a secure workstation, there are two primary tiers of protection:
 
 ### Implementation in System Configuration
 
-The *umask* must be defined in multiple locations to cover both account creation and active shell sessions.
+Two configuration points are required, and they are *not* redundant; they cover different session types:
 
-###### Global Account Defaults
+| Configuration point | Enforced by | Covers |
+| :--- | :--- | :--- |
+| `UMASK` in `/etc/login.defs` | `pam_umask.so` (session stack) and `useradd` | *All* PAM sessions: console logins, SSH, `su`/`sudo -i`, and graphical (GDM/SDDM) sessions. Also sets the mode of new home directories. |
+| `umask` in a `/etc/profile.d/` drop-in | The shell itself, on login | Bourne-compatible login shells only (`sh`, `bash`, `ksh`, `dash`). |
 
-The file */etc/login.defs* controls the initial environment for new users. Ensure only one active *UMASK* entry exists to avoid configuration conflicts.
+The `/etc/login.defs` value is the authoritative one and is the only one that reaches graphical sessions and services. The shell drop-in is a defensive backstop for the case where `pam_umask.so` is missing from the session stack (which is the default on several distributions) and for shells started outside a PAM session. Both MUST be set.
 
-    grep '^UMASK' /etc/login.defs
+###### Global Account Defaults (`/etc/login.defs`)
 
-###### Shell Session Initialization
+Ensure exactly one active *UMASK* entry exists, to avoid configuration conflicts:
 
-The */etc/profile* file sets the environment for interactive shells. Because the *root* user often requires a more permissive mask (*022*) to ensure system-wide readability of configuration files, conditional logic is used.
+    > grep '^\s*UMASK' /etc/login.defs
+    UMASK 027
+
+Confirm that `pam_umask.so` is actually present in the session stack, otherwise this value only affects `useradd`:
+
+    # Debian / Ubuntu / openSUSE
+    > grep pam_umask /etc/pam.d/common-session
+
+    # RHEL / Rocky / AlmaLinux / Fedora / Arch
+    > grep pam_umask /etc/pam.d/system-auth /etc/pam.d/password-auth
+
+If the module is absent, add `session optional pam_umask.so` to the session stack (via `pam-auth-update` on Debian/Ubuntu, or an `authselect` custom profile on the RHEL family).
+
+###### Shell Session Initialization (`/etc/profile.d/`)
+
+The `umask` for login shells MUST be set through a drop-in file in `/etc/profile.d/`, **not** by editing `/etc/profile` directly. `/etc/profile` is a package-managed configuration file on every supported distribution; direct edits trigger conffile conflict prompts on upgrade and are silently reverted by some package managers. Drop-ins in `/etc/profile.d/` are sourced by `/etc/profile` on all supported distributions and survive upgrades untouched.
 
 ### Recommended Conditional Logic
 
-To implement a "really good" standard that protects users without breaking the system, add the following to your */etc/profile*:
+The *root* user and system accounts require the more permissive `022` mask so that files they create (package files, generated configuration, log files) remain world-readable where the system expects that. Regular users get the restrictive mask. Create `/etc/profile.d/50-umask.sh`:
 
-    if [ $UID -gt 199 ]; then
+    > sudo tee /etc/profile.d/50-umask.sh <<'EOF'
+    # Restrictive umask for regular users; system accounts and root keep 022.
+    # UID_MIN is read from /etc/login.defs so the threshold matches the distribution.
+    __uid_min=$(awk '/^\s*UID_MIN/{print $2}' /etc/login.defs 2>/dev/null)
+    [ -n "$__uid_min" ] || __uid_min=1000
+    if [ "$(id -u)" -ge "$__uid_min" ]; then
         umask 027
     else
         umask 022
     fi
+    unset __uid_min
+    EOF
+    > sudo chmod 0644 /etc/profile.d/50-umask.sh
 
-- **Safety Note**: This logic ensures that unprivileged users (UID \> `199`) are restricted to `027`, while system accounts and `root` maintain the standard `022` for compatibility.
+- **Safety Note**: The threshold is read from `UID_MIN` in `/etc/login.defs` (`1000` on all currently supported distributions) rather than being hard-coded. A hard-coded `199` (the value inherited from legacy RHEL `/etc/profile`) would apply the restrictive mask to system accounts in the `200`-`999` range, which on Debian and Ubuntu covers most daemon accounts and can break services that expect group-readable state files.
 
-- **High-Security Modification**: If your threat model requires maximum isolation, change the user value to `umask 077`. Be aware that this will prevent local file sharing between users entirely.
+- **`id -u` instead of `$UID`**: `$UID` is a `bash` and `ksh` variable and is unset under `dash`, which is `/bin/sh` on Debian and Ubuntu. Under `dash`, `[ $UID -gt 199 ]` expands to `[ -gt 199 ]` and fails, leaving the umask unchanged. `id -u` is POSIX and works in every shell.
 
-## Partitioning and Mount Options
+- **High-Security Modification**: If your threat model requires maximum isolation, change the user value to `umask 077` and set `UMASK 077` in `/etc/login.defs`. Be aware that this prevents local file sharing between users entirely, and will break group-collaboration directories.
 
-Partitioning and mount options provide a physical and logical defense-in-depth layer. By isolating high-growth and world-writable directories, you prevent resource exhaustion attacks and restrict the execution of unauthorized payloads.
-
-> **Note:** Re-partitioning and modifying `cryptsetup` or `/etc/fstab` on a running system can lead to *permanent* data loss or a *non-bootable* system. Always perform a full backup before proceeding.
-
-### Partitioning Requirements
-
-Isolating specific directories prevents a "Filesystem Full" condition from impacting the entire OS. The following directories SHOULD reside on dedicated partitions:
-
-- **`/boot`**: Isolates the kernel and bootloader.
-
-- **`/home`**: Prevents user data from consuming system space.
-
-- **`/var` & `/var/log`**: Ensures application data and logs don't fill the root partition.
-
-- **`/var/log/audit`**: Specifically protects audit logs from being overwritten or causing system crashes during high activity.
-
-- **`/tmp`**: World-writable space susceptible to resource flooding.
+- **Non-login shells**: Neither mechanism applies to a non-login interactive shell (a new terminal tab in a graphical session). Such shells inherit the umask of the graphical session, which is why the `pam_umask.so` path above is the one that actually matters on workstations.
 
 ###### Verification
 
-Use `findmnt` to inspect current mount points:
+    > umask
+    0027
 
-    > findmnt -v
+    # Confirm the effective result rather than the configuration
+    > touch /tmp/umask-test && stat -c '%a' /tmp/umask-test && rm /tmp/umask-test
+    640
 
-### Restrictive Mount Options
+## Securing the Path Environment Variable
 
-Apply the **Principle of Least Privilege** to your filesystems using specific flags:
+The `PATH` environment variable lists the directories searched by the shell for executable commands. If a directory in the `PATH` is writable by non-privileged users (globally writable), it creates a severe vulnerability. Attackers can place a malicious executable with the same name as a common command, such as `ls` or `cd`, in that directory. When a privileged user executes the command, the trojan may run instead of the legitimate binary, leading to privilege escalation.
 
-- **`nodev`**: Do not interpret character or block special devices on the filesystem.
+The system MUST NOT include any globally writable directories in the default `PATH`.
 
-- **`nosuid`**: Disallow the set-user-identifier (SUID) bits to take effect.
+### Check for Globally Writable Paths
 
-- **`noexec`**: Prevent the direct execution of any binaries on the mounted filesystem.
+Standard system directories like `/bin`, `/usr/bin`, `/sbin`, and `/usr/sbin` MUST NOT be writable by anyone except the `root` user.
 
-###### Recommended `/etc/fstab` Configuration
+Run the following command to check common system directories for the world-writable bit (`/0002`):
 
-| Partition | Recommended Options | Purpose |
-| :--- | :--- | :--- |
-| `/tmp` | `defaults,nodev,nosuid,noexec` | Block malware execution in temp space. |
-| `/dev/shm` | `defaults,nodev,nosuid,noexec` | Harden shared memory. |
-| `/home` | `defaults,nodev,nosuid` | Prevent SUID abuse in user space. |
-| `/boot` | `defaults,nodev,nosuid,noexec` | Protect boot files from being used as vectors. |
+    > find /usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin -type d -perm /0002 2>
+    (*LATEX@\lineBreakWithArrow@LATEX*)/dev/null
 
-### Encryption (LUKS)
+The output MUST be empty. Any listed directory represents an immediate security risk and requires manual intervention.
 
-For portable devices, **Full Disk Encryption (FDE)** is the standard for protecting data-at-rest. LUKS (Linux Unified Key Setup) provides a standardized header and multi-slot key management system.
+### Location of PATH Configuration
 
-###### Setting up a LUKS Partition
+The `PATH` variable is usually defined in global shell configuration files. You should review these to ensure no insecure or relative paths (like `.`) are being added:
 
-1.  **Initialize the LUKS container**:
+- `/etc/profile`
 
-<!-- -->
+- `/etc/bash.bashrc`
 
-    # WARNING: This wipes all data on the target partition
-    > cryptsetup luksFormat /dev/sdXn
+- Files within `/etc/profile.d/`
 
-1.  **Map the device**:
+- **Security Note**: Regardless of where the variable is set, the primary control is ensuring the *target directories* are not writable by untrusted users.
 
-<!-- -->
-
-    > cryptsetup open /dev/sdXn crypt_data
-
-1.  **Format and mount**:
-
-<!-- -->
-
-    > mkfs.ext4 /dev/mapper/crypt_data
-    > mount /dev/mapper/crypt_data /mnt
-
-###### Automated Unlocking via `/etc/crypttab`
-
-To ensure the OS unlocks the device during boot, add it to `/etc/crypttab`:
-
-    # TARGET        SOURCE DEVICE       KEY FILE    OPTIONS
-    crypt_data      UUID=<your-uuid>    none        luks,discard
-
-###### Swap Encryption
-
-Swap space can leak sensitive information (e.g., encryption keys or passwords cached in RAM) to the disk.
-
-    # /etc/crypttab entry for volatile (random key) swap
-    > swap /dev/sdXn /dev/urandom swap,cipher=aes-xts-plain64,size=256
-
-> **Note:** Using `/dev/urandom` for swap encryption breaks hibernation (Suspend-to-Disk) because the key is lost on every reboot.
-
-### Polyinstantiated Directories
-
-Polyinstantiation creates private, isolated instances of `/tmp` and `/var/tmp` for each user session, mitigating symlink attacks and information leakage between users.
-
-Configure `/etc/security/namespace.conf`:
-
-    /tmp     /tmp-inst/            level      root,adm
-    /var/tmp /var/tmp-inst/        level      root,adm
-
-### Additional Filesystem Hardening
-
-Beyond partitioning, specific permissions must be enforced:
-
-- **Sticky Bits**: All world-writable directories MUST have the sticky bit set to prevent users from deleting files owned by others.
-
-- **Critical Files**: Ensure permissions for `/etc/shadow` (640) and `/etc/passwd` (644) are strictly maintained to prevent unauthorized credential access.
-
-## Enforcing Restrictive Mount Options
-
-Applying restrictive mount options in `/etc/fstab` is a highly effective way to implement security controls that cannot be bypassed by changing file permissions. These settings implement kernel-enforced limitations on file system capabilities, significantly mitigating local attack vectors.
-
-The following options are MANDATORY for partitions that store user-writable data, temporary files, or volatile memory:
-
-| Option | Rationale | Attack Mitigated |
-| :--- | :--- | :--- |
-| `nodev` | Prevents device files (special files) from being interpreted. | Creation of malicious device files (e.g., character devices) in user-writable directories. |
-| `nosuid` | Prevents execution of SUID/SGID binaries on the partition. | Exploitation of flawed SUID programs installed in user areas, preventing local privilege escalation. |
-| `noexec` | Prevents the direct execution of any executable file on the partition. | Execution of malware, scripts, or compiled exploits stored in temporary directories. |
-
-### Configuration for Temporary Filesystems
-
-Filesystems used for temporary data (e.g., `/tmp`, `/var/tmp`, `/dev/shm`) MUST be mounted with all three restrictive options: `nodev`, `nosuid`, and `noexec`.
-
-###### Example `/etc/fstab` Entry for `/tmp`
-
-    /dev/mapper/vg0-tmp /tmp ext4 defaults,nodev,nosuid,noexec 0 2
-
-To verify the current mount status for `/tmp`:
-
-    > findmnt -n /tmp
-    /tmp ext4 [rw,nosuid,nodev,noexec,relatime]
-
-### Configuration for User Filesystems
-
-Partitions containing user home directories (e.g., `/home`) MUST be mounted with at least `nodev` and `nosuid` to prevent users from installing malicious SUID programs or device files in their personal directories. Execution of regular user binaries is generally permitted here, meaning `noexec` is usually omitted unless dictated by strict policy.
-
-Example /etc/fstab entry for `/home`:
-
-    /dev/mapper/vg0-home /home ext4 defaults,nodev,nosuid 0 2
-
-### Applying Changes
-
-After modifying `/etc/fstab`, the changes can be applied without a full system reboot by remounting the individual filesystems:
-
-    > sudo mount -o remount /tmp
-    > sudo mount -o remount /home
+- **Manual Action**: If a directory is found to be writable, investigate the cause before changing permissions. Use `chmod o-w <directory>` to secure it once the risk is understood.
 
 ## Hardening the Proc Filesystem
 
-The `/proc` filesystem provides a window into the running kernel and processes. By default, any local user can inspect nearly all process information, including the process ID (PID), command line arguments, environment variables, and memory maps of other users, including service accounts and the root user. This information leakage is critical for attackers performing reconnaissance or planning a local privilege escalation (LPE) attack.
+The `/proc` filesystem exposes the command line, environment and memory maps of every
+running process, which is useful reconnaissance for a local attacker.
 
-The system MUST restrict visibility into the `/proc` filesystem using the `hidepid` mount option.
+The usual control is the `hidepid=2` mount option. It is deliberately **not** mandated in
+this guide, because on a desktop client it breaks the session: `systemd --user`, `polkit`
+and parts of the GNOME and KDE session need to see processes they do not own, and
+`hidepid` without a correctly configured `gid=` option leaves users unable to log in
+graphically.
 
-### Correctly Implementing Hidepid
+If you need it on a server, apply it with a group exemption and test a login before
+relying on it:
 
-The `hidepid` option is applied to the `proc` filesystem definition in `/etc/fstab`. Setting `hidepid` to `2` provides the highest level of security by making process directories (`/proc/<PID>`) invisible to users who are not the process owner and are not part of the specified administrative group.
+    proc /proc proc defaults,hidepid=2,gid=<admin_gid> 0 0
 
-The `hidepid=2` setting ensures: \* Processes are invisible to unprivileged users unless they belong to the process's owning group. \* The system only reveals processes necessary for the user to see (typically only their own, or system-critical processes via the designated group).
+For a client, the practical protections against the same reconnaissance are already in this
+guide: `kernel.dmesg_restrict`, `kernel.kptr_restrict` and `kernel.yama.ptrace_scope`.
 
-To enforce this, ensure your `/etc/fstab` entry for `/proc` includes the `hidepid=2` option:
-
-    proc    /proc   proc    defaults,hidepid=2      0       0
-
-> **Note:** If you need specific administrative users (e.g., members of the `adm` or `monitoring` group) to see all processes, you should use the combination `defaults,hidepid=2,gid=<group_id>`. This allows users in that `<group_id>` to view all processes, while denying access to others.
-
-### Applying Changes
-
-After modifying `/etc/fstab`, the change MUST be applied by remounting the `/proc` filesystem:
-
-    > sudo mount -o remount /proc
-
-#### Verification
-
-After applying the changes, an unprivileged user attempting to list the `/proc` directory should only see a limited number of directories (mostly virtual files, and their own process directories if `gid` is not used).
 
 ## Audit and Restrict SUID/SGID Executables
 
@@ -1954,44 +1709,739 @@ Reassigning the file ensures that future user creation or system operations will
 
 ## Polyinstantiation of Temporary Directories
 
-Polyinstantiation is an advanced hardening technique that utilizes Linux namespaces and mount points to provide each user or session with a private, isolated instance of a directory. This is primarily aimed at high-risk, world-writable directories such as `/tmp` and `/var/tmp`.
+Polyinstantiation gives each user a private `/tmp` and `/var/tmp`, which prevents
+information leaking between users through predictable temporary filenames.
 
-The isolation prevents unauthorized information leakage and denial-of-service (DoS) attacks, as files created by one user (or a sensitive service) are invisible to other unprivileged users. This is a mandatory control for systems handling highly sensitive data.
+It is **not** recommended for a client. A shared `/tmp` is load-bearing on a desktop
+session: the X11 socket directory `/tmp/.X11-unix`, PulseAudio and PipeWire sockets and a
+number of application IPC paths all live there, and giving each session a private namespace
+breaks them. A misplaced `pam_namespace.so` line in the session stack also prevents login
+outright.
 
-### Configure Namespace Definitions
+On a single-user client the threat it addresses, one local user reading another's temporary
+files, largely does not exist. The mount options in *Partitioning and Mount Options*
+(`nodev,nosuid,noexec` on `/tmp`) and the sticky bit cover the realistic cases.
 
-The file `/etc/security/namespace.conf` defines which directories should be polyinstantiated, what type of user/group should be isolated, and the type of temporary filesystem to use (e.g., `tmpfs`).
 
-The following lines MUST be added to `/etc/security/namespace.conf` to isolate the temporary directories based on the user ID (`user`) upon login:
+## Disable Core Dumps
 
-    # Directory   Type   Context    Method
-    /tmp         tmpfs  user       create
-    /var/tmp     tmpfs  user       create
+A core dump is a memory image file created by the operating system when a program terminates unexpectedly (crashes). While useful for developers and system administrators for debugging purposes, core dump files often contain sensitive data, including passwords, encryption keys, and proprietary information that was held in memory at the time of the crash. Storing these files on disk represents a significant data confidentiality risk.
 
-This configuration instructs the system to create a new, private `/tmp` and `/var/tmp` directory instance every time a new user session begins.
+To mitigate this risk, the system MUST be configured to prevent the creation of core dump files for all users and processes.
 
-### Activate the PAM Module
+### Configure User Limits (`/etc/security/limits.conf`)
 
-The logic for applying polyinstantiation and manipulating the mount namespace at login is handled by the **`pam_namespace.so`** module. This module MUST be activated in the session stack of the relevant PAM configuration files (`/etc/pam.d/login` and `/etc/pam.d/sshd` are common targets).
+The primary method for disabling core dumps for user processes is to set the hard limit for the core file size to zero (`0`) in the `/etc/security/limits.conf` file. This prevents unprivileged users from writing core dumps.
 
-The following entry MUST be present in the session stack of the PAM configuration files:
+The following line MUST be added or verified to exist in `/etc/security/limits.conf`:
 
-    session required pam_namespace.so
+    * hard core 0
 
-> **Warning:** Due to the complexity of the PAM stack and the potential for disrupting critical services, enabling `pam_namespace.so` MUST be tested rigorously. Misconfiguration can lead to the inability to start remote or local sessions.
+- The asterisk (`*`) applies this rule to all users.
 
-### Runtime Verification
+- `hard` sets an enforced maximum value.
 
-After implementing the configuration and logging in as two different unprivileged users (UserA and UserB), run the `mount` command in both sessions and filter for the temporary directories:
+- `core 0` sets the maximum size of a core file to zero bytes.
 
-    > mount | grep tmp
-    tmpfs on /tmp type tmpfs (rw,nosuid,nodev,relatime,size=...)
+###### Verification
 
-While the mount point remains `/tmp`, the underlying mount namespace and contents are isolated. You MUST verify that a file created by UserA in `/tmp` is not visible or accessible by UserB.
+    > grep -E "^\*\s+hard\s+core\s+0$" /etc/security/limits.conf
+    * hard core 0
 
-# Application Security & Logging
+### Disable the `systemd-coredump` Service
 
-Even a well-hardened kernel and file system can be undermined by applications operating without sufficient logging, access control, or confinement. This section addresses the security posture of core system services: ensuring `auditd` captures a complete and tamper-evident record of security-relevant events, configuring `syslog` and `journald` for reliable and integrity-protected log collection, restricting `cron` and `systemd` timer access to authorized users, hardening `systemd` unit configurations to limit service privileges, and establishing a Mandatory Access Control framework to enforce least-privilege execution boundaries across the system.
+Modern Linux distributions using `systemd` may use the `systemd-coredump` service to manage and store core dumps in the journal. To fully disable core dump creation, this service MUST be stopped, disabled, and masked to prevent it from being accidentally started by another service or administrator.
+
+###### Remediation
+
+    > sudo systemctl stop systemd-coredump
+    > sudo systemctl disable systemd-coredump
+    > sudo systemctl mask systemd-coredump
+
+The `mask` command ensures that the service unit file cannot be started even if another service attempts to pull it as a dependency, providing the strongest form of disabling.
+
+###### Verification
+
+    > sudo systemctl is-enabled systemd-coredump
+    masked
+
+# Phase 6: Kernel and Network Stack Parameters
+
+Runtime kernel parameters are applied through `sysctl` and take effect immediately. They are set before the firewall and service controls of Phase 7 because several of them (reverse path filtering, redirect handling, SYN cookies) harden the stack that those controls then filter.
+
+## Kernel Hardening
+
+The Linux kernel is the core of your operating system. Hardening it involves configuring *runtime parameters* and *module restrictions* to reduce the available attack surface for both local and remote threats.
+
+### Runtime Self-Protection
+
+Modern kernels include features to make exploitation significantly more difficult. These are primarily managed via *sysctl*.
+
+- **ASLR (Address Space Layout Randomization)**: By setting `kernel.randomize_va_space=2`, the kernel randomizes where programs are loaded into memory, making it harder for attackers to predict target addresses for buffer overflows.
+
+- **Information Leak Prevention**: Restricting *dmesg* access (`kernel.dmesg_restrict=1`) and hiding kernel pointers (`kernel.kptr_restrict=2`) prevents unprivileged users from gathering data needed to bypass security features like *KASLR*.
+
+- **Ptrace Scope**: Setting `kernel.yama.ptrace_scope=1` ensures that a process can only be debugged by its parent, preventing malicious software from inspecting or injecting code into other running applications.
+
+- **Disabling Core Dumps**: Setting `fs.suid_dumpable=0` prevents sensitive memory from being written to disk during application crashes, which could otherwise be mined for credentials or secrets.
+
+### eBPF and Sandboxing
+
+While eBPF provides powerful tracing and networking capabilities, it also presents a significant attack surface if left open to unprivileged users.
+
+- **eBPF Restrictions**: Setting `kernel.unprivileged_bpf_disabled=1` prevents non-root users from loading eBPF programs. Additionally, `net.core.bpf_jit_harden=2` enables JIT hardening to mitigate JIT spraying attacks.
+
+- **User Namespace Cloning**: disabling unprivileged user namespaces (`kernel.unprivileged_userns_clone=0`) is deliberately *not* recommended here. It breaks Flatpak and rootless containers, and it also disables the user-namespace sandboxes that Chromium and Firefox rely on, so on a desktop client it removes more protection than it adds.
+
+- **Filesystem Protection**: Setting `fs.protected_fifos=2` enables strict FIFO protection to prevent race conditions in named pipes, a common class of local privilege escalation.
+
+### Network Stack Parameters
+
+In a Zero Trust environment, the client must protect itself even from the local network. These settings harden the stack against local MitM attacks and spoofing, which are common when connecting to untrusted networks (e.g., public Wi-Fi or compromised internal segments). The network stack should be configured to prioritize security and integrity over legacy routing features.
+
+- **Anti-Spoofing**: Enabling the Reverse Path Filter (`net.ipv4.conf.all.rp_filter=1`) forces the kernel to verify that a packet arrived on the interface it should have, preventing IP spoofing attacks.
+
+- **Flooding Protection**: TCP SYN cookies (`net.ipv4.tcp_syncookies=1`) protect the system from *Denial of Service* attacks by validating connection requests without exhausting system resources.
+
+- **Disabling Routing & Redirects**: A personal workstation should not act as a router or accept external routing updates.
+
+  - `net.ipv4.ip_forward=0` (Disables forwarding)
+
+  - `net.ipv4.conf.all.send_redirects=0` (Disables sending ICMP redirects)
+
+  - `net.ipv4.conf.all.accept_redirects=0` (Disables accepting ICMP redirects)
+
+  - `net.ipv4.conf.all.accept_source_route=0` (Disables source-routed packets)
+
+- **ICMP Hardening**: Setting `net.ipv4.icmp_ignore_bogus_error_responses=1` ignores malformed ICMP error responses to reduce log noise and potential DoS vectors.
+
+### Restricting Kernel Modules
+
+Unnecessary kernel modules can contain vulnerabilities. If a feature is not used, its code should not be allowed to execute.
+
+- **USB Mass Storage**: blacklisting the `usb-storage` module is a common recommendation, but it disables *every* USB mass storage device on the machine, permanently and for every user. On a client that is a functional regression rather than a hardening measure, and it is not part of this guide. Where removable media genuinely has to be controlled, use USBGuard, which authorises devices individually and can be adjusted without a reboot.
+
+- **Legacy Protocols**: Protocols like `DCCP` (Datagram Congestion Control Protocol) and `SCTP` (Stream Control Transmission Protocol) are rarely used on desktops and should be blacklisted to close potential network entry points.
+
+### Cryptography (FIPS)
+
+FIPS-validated cryptography is a regulatory requirement for specific environments, not a
+client hardening control, and it is not part of this guide. Enabling FIPS mode requires
+certified packages and bootloader changes, and it disables non-compliant algorithms, which
+can break SSH connectivity and other services. Where it is mandated, follow the
+distribution vendor's procedure rather than a generic hardening step.
+
+
+###### Implementation Procedure
+
+To apply these settings persistently, create dedicated configuration files:
+
+    # General Kernel Hardening
+    > sudo tee /etc/sysctl.d/10-kernel-hardening.conf <<EOF
+    kernel.dmesg_restrict=1
+    kernel.randomize_va_space=2
+    fs.suid_dumpable=0
+    kernel.yama.ptrace_scope=1
+    kernel.kptr_restrict=2
+    kernel.unprivileged_bpf_disabled=1
+    net.core.bpf_jit_harden=2
+    fs.protected_fifos=2
+    EOF
+
+    # Network Hardening
+    >sudo tee /etc/sysctl.d/90-network-hardening.conf <<EOF
+    net.ipv4.tcp_syncookies=1
+    net.ipv4.conf.all.rp_filter=1
+    net.ipv4.conf.all.accept_redirects=0
+    net.ipv4.conf.all.accept_source_route=0
+    net.ipv4.icmp_ignore_bogus_error_responses=1
+    net.ipv4.ip_forward=0
+    net.ipv4.conf.all.send_redirects=0
+    EOF
+
+    # Module Blacklisting
+    > sudo tee /etc/modprobe.d/blacklist-unnecessary.conf <<EOF
+    blacklist dccp
+    blacklist sctp
+    EOF
+
+    # Apply sysctl changes immediately
+    > sudo sysctl -p /etc/sysctl.d/10-kernel-hardening.conf
+    > sudo sysctl -p /etc/sysctl.d/90-network-hardening.conf
+
+## IPv6 Attack Surface Reduction
+
+### IPv6 Stack Hardening
+
+As a foundational pillar of modern networking, IPv6 is essential for system interoperability and internal container orchestration. Rather than disabling the stack, which risks breaking local service discovery and modern application dependencies, security efforts must focus on hardening the protocol parameters to mitigate discovery and redirection attacks.
+
+###### Privacy Extensions (Temporary Addresses)
+
+By default, IPv6 addresses can expose a device's hardware (MAC) address via EUI-64 identifiers, allowing for global host tracking. We enforce *Privacy Extensions* ([RFC 4941](https://datatracker.ietf.org/doc/html/rfc4941)) to ensure the system generates short-lived, random addresses for all outgoing traffic.
+
+> **Note:** Setting `net.ipv6.conf.all.use_tempaddr = 2` ensures that temporary addresses are preferred over static, hardware-derived identifiers.
+
+###### Disabling Source Routing and Redirects
+
+Paralleling IPv4 security measures\[cite: 1\], the IPv6 stack must be configured to reject packets attempting to dictate the return path or manipulate local routing tables via ICMPv6 redirects.
+
+    # Prevent MitM via routing redirects
+    net.ipv6.conf.all.accept_redirects = 0
+    net.ipv6.conf.default.accept_redirects = 0
+
+    # Disable source routing (deprecated and vulnerable)
+    net.ipv6.conf.all.accept_source_route = 0
+    net.ipv6.conf.default.accept_source_route = 0
+
+###### Router Advertisements (RA) Policy
+
+While Router Advertisements are often required for dynamic connectivity (SLAAC), they present a significant attack vector if the kernel processes all flags unconditionally. We harden the RA handling to accept the prefix while ignoring potentially malicious flags that could be used for Denial of Service (DoS).
+
+> **Note**: In environments with static IP assignments, set `accept_ra = 0`. For workstations: maintain `accept_ra = 1` for connectivity but strictly enforce `accept_redirects = 0` to mitigate rogue router risks.
+
+###### Implementation Procedure
+
+To apply a comprehensive hardening profile immediately:
+
+    # Apply IPv6 Hardening
+    > sudo tee /etc/sysctl.d/90-ipv6-harden.conf <<EOF
+    # Privacy Extensions (RFC 4941)
+    net.ipv6.conf.all.use_tempaddr = 2
+    net.ipv6.conf.default.use_tempaddr = 2
+
+    # MitM & Spoofing Protection
+    net.ipv6.conf.all.accept_redirects = 0
+    net.ipv6.conf.default.accept_redirects = 0
+    net.ipv6.conf.all.accept_source_route = 0
+    net.ipv6.conf.default.accept_source_route = 0
+
+    # Router Advertisement Hardening
+    net.ipv6.conf.all.accept_ra_pinfo = 1
+    net.ipv6.conf.all.accept_ra_defrtr = 1
+    EOF
+
+    # Load the new parameters immediately
+    > sudo sysctl -p /etc/sysctl.d/90-ipv6-harden.conf
+
+## Ensure Correct Loopback and Local Host Configuration
+
+The `/etc/hosts` file acts as a local address book for your computer. It allows the system to find itself and other local services before reaching out to the Internet. Proper configuration prevents apps from hanging while they wait for *DNS* responses that will never come.
+
+### Loopback Configuration
+
+The *loopback address* is a virtual interface used for internal communication. If this is missing or misconfigured, core system components and local applications (like your web browser or printing services) may fail to start.
+
+Both *IPv4* and *IPv6* versions MUST be defined:
+
+    127.0.0.1       localhost
+    ::1             localhost
+
+To verify these are present, use *grep* with a focus on the start of the line:
+
+    > grep -E '^\s*127\.0\.0\.1\s+localhost' /etc/hosts
+    127.0.0.1   localhost
+
+### Local Hostname Resolution
+
+Your computer also needs to know its own name (*hostname*). On personal Linux desktops, it is standard practice to map the hostname to *127.0.1.1*. This keeps it separate from the generic *localhost* entry and avoids conflicts with some network services.
+
+First, check your current hostname:
+
+    > hostname
+    my-linux-laptop
+
+Then, ensure it appears in your *hosts* file mapped to a local address:
+
+    > grep "$(hostname)" /etc/hosts
+    127.0.1.1   my-linux-laptop
+
+> **Note**: Never map your hostname to an external *IP* address in this file if you move between networks (e.g., using a laptop on public Wi-Fi). Always use the *127.x.x.x* loopback range for your own hostname to ensure your traffic stays local.
+
+> **Modifying the File**: Because this is a system-critical file, you MUST use *sudo* to edit it. A simple typo can break your network connectivity entirely.
+
+# Phase 7: Services and Network Exposure
+
+Reduce the attack surface before filtering it: a service that is not installed needs no firewall rule. Remove or confine services first, then apply the default-deny policies. The firewall and TCP wrapper controls at the end of this phase are the second most common cause of remote lockout after PAM, and are marked accordingly.
+
+## Verifying that Vulnerable and Not Required Software Is Disabled
+
+Hardening a Linux system MUST include identifying and removing software that uses legacy protocols or exposes services to the network unnecessarily.
+
+### Remove Insecure Legacy Protocols
+
+Insecure protocols transmit credentials and data in clear text. These MUST be purged from the system. Verification is done by checking the `dpkg` status.
+
+    > dpkg -l | grep -E '^ii\s+(rsh-client|telnetd|vsftpd)'
+    (Output should be empty)
+
+- **R-Services (*rlogin*, *rsh*, *rcp*)**: These are fully replaced by the SSH suite.
+
+- **Telnet Server (*telnetd*)**: Transmits all data unencrypted.
+
+- **FTP Services (*vsftpd*, *pure-ftpd*)**: MUST be replaced with SFTP for secure file transfers.
+
+- **Network Protocol Blacklisting**: Protocols like DCCP or SCTP should be disabled if not needed. Check via:
+
+<!-- -->
+
+    > lsmod | grep -E 'dccp|sctp'
+
+### Restrict or Disable Potentially Necessary Services
+
+Some services provide functionality required locally. Instead of removal, these MUST be restricted to the loopback interface (`127.0.0.1`) to prevent network exposure.
+
+- **CUPS Printing (*cups*)**: If printing is required, the daemon MUST only listen on localhost. Verify the configuration:
+
+      > grep "^Listen" /etc/cups/cupsd.conf
+      Listen localhost:631
+
+- **Avahi Daemon (*avahi-daemon*)**: Provides Zero-configuration networking. It MUST be masked unless automatic discovery is strictly required.
+
+      > systemctl is-active avahi-daemon
+
+- **Bluetooth (*bluetooth*)**: On systems where Bluetooth is not used, the service MUST be masked to close the wireless attack vector.
+
+### Essential Hardening Targets
+
+The following services MUST be checked. If they are not essential, they MUST be disabled.
+
+- **TFTP Service (*tftpd*)**: Often used for network booting; MUST be removed if not in use.
+
+- **File Sharing (*nfs*, *samba*)**: These MUST be restricted via firewall rules to specific trusted subnets if required.
+
+- **Graphical Remote Desktop**: Remote access tools like VNC or RDP increase risk and MUST be disabled by default. Check for listening ports:
+
+      > ss -tulpn | grep -E '5900|3389'
+
+## SSH Client Security
+
+Secure Shell (SSH) is a dual-purpose tool. While it is famous for managing servers, *end-users* primarily use it as a *client* to connect to other machines.
+
+### Eliminate the Server Attack Surface
+
+By default, many Linux distributions install or enable the SSH server (*sshd*). For a personal workstation, this is an unnecessary open door. If you do not need to log into your computer from another device, the server component MUST be removed.
+
+- **Verification**: Use the following command to check if the server is active. If it returns any result, the service is installed.
+
+      > dpkg -l | grep openssh-server
+
+- **Action**: Purging the package completely removes the configuration and the listening service, ensuring no one can attempt to brute-force your machine over the network (e.g., on Debian/Ubuntu: `sudo apt-get purge -y openssh-server`).
+
+### Maintain the Secure Client
+
+The SSH *client* is the part you use to initiate connections (e.g., `ssh user@remote-host`). This component is safe to keep and should be updated regularly to ensure the latest cryptographic patches are applied.
+
+- **Safe Usage**: Even with the server removed, your client remains functional. You can still use *SFTP* through file managers like *Nautilus* or *Dolphin* to transfer files to remote storage securely.
+
+## CUPS Security Hardening
+
+### Disabling `cups-browsed`
+
+The Common UNIX Printing System (CUPS) is a modular printing system that allows a local system to act as a print server. The cups-browsed service is responsible for discovering remote CUPS printers and advertising local shared printers on the network, typically using protocols like DNS-SD (Bonjour/mDNS).
+
+While useful in certain network printing environments, running unnecessary network services significantly increases the attack surface of a system. The cups-browsed service, in particular, has been associated with critical remote code execution vulnerabilities (such as CVE-2024-47176). In these scenarios, attackers can potentially gain unauthorized access or control of the system by sending crafted packets to UDP port 631 and tricking the service into communicating with a malicious server.
+
+Unless the system explicitly requires the automatic discovery or browsing of network printers, the cups-browsed service must be disabled and stopped. For most server or hardened workstation environments where printing is either not required or managed manually, this service should not be running.
+
+###### Service Status Verification
+
+The following command can be used to check the status of the service:
+
+    > systemctl status cups-browsed
+
+The objective is for the output to show Active: inactive (dead) and for the service to be disabled. If the service is active or enabled, remediation is required.
+
+###### Remediation Procedure
+
+To stop the service immediately and prevent it from starting automatically at system boot, use the following command:
+
+    > sudo systemctl disable --now cups-browsed
+
+This command both stops the running service and removes the symlink that enables it at startup. For systems requiring even stricter enforcement, the service can be masked to prevent any other process from triggering it:
+
+    > sudo systemctl mask cups-browsed
+
+## Disable or Remove Unnecessary File Sharing Services (Samba)
+
+### Samba (SMB)
+
+The Samba service provides *SMB/CIFS* file and print services for communication with Windows clients and other operating systems. On servers or workstations that do not explicitly need to act as a file or print server for Windows environments, the Samba service MUST be disabled or removed.
+
+File sharing services are a significant network attack vector and have historically been subject to severe vulnerabilities. Disabling or removing this service is a fundamental step in reducing the system's attack surface.
+
+The primary systemd units for the Samba service are typically `smbd` (the main daemon) and `nmbd` (NetBIOS name service).
+
+###### Check and Disable the Samba Service
+
+The following commands verify the status of the primary Samba service daemons:
+
+    > sudo systemctl status smbd
+    > sudo systemctl status nmbd
+
+The desired output for these commands is that the services are `Active: inactive (dead)` and disabled at boot.
+
+To ensure the services are stopped immediately and prevented from starting at boot, use the following command:
+
+    > sudo systemctl disable --now smbd nmbd
+
+###### Removing the Samba Package
+
+If Samba is not required for any function on the system, the packages SHOULD be completely removed. This is the most secure approach, as it eliminates the possibility of the service being inadvertently started or exploited.
+
+> **Note:** The automated hardener cannot typically determine if the removal of a package will break other system dependencies. Therefore, complete removal MUST be performed manually by the administrator after assessing the impact.
+
+Use the appropriate command for your distribution to completely remove the Samba package and its associated configuration files:
+
+###### For Debian/Ubuntu-based Systems
+
+    > sudo apt purge samba
+
+###### For RHEL/CentOS-based Systems
+
+    > sudo yum remove samba
+
+###### For SUSE/openSUSE-based Systems
+
+    > sudo zypper remove samba
+
+## DNS Resolver Security
+
+The Domain Name System (DNS) translates human-readable names into IP addresses. If this process is intercepted, attackers can redirect your browser to malicious websites. Protecting DNS integrity is vital for personal privacy and security.
+
+### Restrict Local Resolver Exposure
+
+Many Linux desktops run a local resolver like *systemd-resolved* or *Unbound*. These services MUST be restricted to the loopback interface (`127.0.0.1`). If they listen on all interfaces, they could be exploited by other devices on your local network.
+
+To verify your resolver is only listening locally:
+
+    > sudo ss -tuln | grep :53
+    tcp   LISTEN 0      4096      127.0.0.53%lo:53         0.0.0.0:*
+
+*The output should only show loopback addresses like 127.0.0.x or ::1.*
+
+### Secure Transport and Validation
+
+Standard DNS is unencrypted. To prevent Machine-in-the-Middle attacks, your system should use *DNS-over-TLS (DoT)* to encrypt queries or *DNSSEC* to cryptographically verify responses.
+
+- **Systemd-resolved**: This is the default on most modern desktops. Enable encryption by editing */etc/systemd/resolved.conf*. Use `opportunistic`, which encrypts where the resolver supports DNS-over-TLS and falls back to plain DNS where it does not. `DNSOverTLS=yes` is strict: if any configured resolver lacks DoT support, *all* name resolution fails, which on a client is indistinguishable from the network being down.
+
+      [Resolve]
+      DNSOverTLS=opportunistic
+
+- **Validation**: Tools like *Unbound* can perform *DNSSEC* validation locally, ensuring that the data received has not been tampered with by an ISP or attackers.
+
+### Protect Resolver Configuration
+
+The file `/etc/resolv.conf` tells the system which DNS servers to use. It MUST be protected against unauthorized modification, so that malware or an unprivileged user cannot redirect name resolution.
+
+###### `/etc/resolv.conf` Is Usually a Symbolic Link
+
+On most modern distributions `/etc/resolv.conf` is *not* a regular file. It is a symbolic link into a runtime directory managed by the resolver:
+
+| Distribution / stack | `/etc/resolv.conf` points to | Managed by |
+| :--- | :--- | :--- |
+| Ubuntu, Debian (with `systemd-resolved`), Fedora, Arch | `../run/systemd/resolve/stub-resolv.conf` | `systemd-resolved` |
+| RHEL, Rocky, AlmaLinux (NetworkManager) | regular file, rewritten in place | `NetworkManager` |
+| openSUSE | `/run/netconfig/resolv.conf` | `netconfig` |
+| Minimal / static configurations | regular file | administrator |
+
+This has three consequences that a naive permission check gets wrong:
+
+1.  **Symbolic links have no meaningful permissions of their own.** On Linux a symlink's mode is always `0777` and `chmod` cannot change it; `chmod` follows the link and modifies the *target*. A control that claims to "protect the link itself" is therefore meaningless. Note also that `stat` does *not* follow symlinks by default, so `stat -c '%a' /etc/resolv.conf` returns `777` on any resolver-managed system; `stat -Lc` is required to inspect the target.
+
+2.  **The target usually lives on a `tmpfs`.** `/run/systemd/resolve/stub-resolv.conf` is regenerated from scratch on every boot and on every network change. Any `chmod` applied to it is discarded, so a permission fix against that path is not persistent and gives a false sense of assurance.
+
+3.  **The number `0644` is not itself the control.** What matters is that the *effective* file is owned by `root` and is not writable by group or other. `0600`, `0640` and `0644` all satisfy that; `0620` does not, despite being numerically smaller.
+
+###### The Actual Control
+
+Verify the resolved target, not the link, and check ownership together with the write bits:
+
+    > readlink -f /etc/resolv.conf
+    /run/systemd/resolve/stub-resolv.conf
+
+    > stat -Lc '%U:%G %a %n' "$(readlink -f /etc/resolv.conf)"
+    root:root 644 /run/systemd/resolve/stub-resolv.conf
+
+The file MUST be owned by `root` and MUST NOT carry the write bit for group or other. Where the resolver manages the file, this is already the case, and the check exists to *detect tampering* rather than to be routinely remediated.
+
+Where `/etc/resolv.conf` is a regular file maintained by the administrator, enforce the permissions directly:
+
+    > sudo chown root:root /etc/resolv.conf
+    > sudo chmod 0644 /etc/resolv.conf
+
+> **Note:** For resolver-managed systems, the durable control is not the permissions of the generated file but the integrity of the *configuration that generates it*: `/etc/systemd/resolved.conf` and `/etc/systemd/resolved.conf.d/` for `systemd-resolved`, `/etc/NetworkManager/` for NetworkManager, `/etc/sysconfig/network/config` for `netconfig`. These MUST be `root`-owned and not group- or world-writable, and they are what an attacker has to modify for a change to survive a reboot.
+
+> **Note:** Making `/etc/resolv.conf` immutable with `chattr +i` is sometimes suggested to "lock" the resolver. This MUST NOT be done on a system running `systemd-resolved` or NetworkManager: the managing service will fail to update the file, log errors on every network change, and in some configurations delay boot. Replace the link with a static file first if a static resolver configuration is genuinely required.
+
+## Configuring and Hardening the Host Firewall
+
+> **Warning (lockout risk):** This control can prevent you from logging in or from reaching the system over the network. Apply it under the *Session Safety Protocol* described in Phase 0.
+
+
+A host-based firewall is a *mandatory* component that implements *Defense-in-Depth* by blocking unwanted traffic from the Internet or local network. The specific firewall tool differs by distribution:
+
+- **Ubuntu / Debian / Arch**: *Uncomplicated Firewall (UFW)*, a frontend for `nftables`/`iptables`.
+
+- **Rocky / Fedora / RHEL / OpenSUSE**: *firewalld*, a zone-based dynamic firewall daemon.
+
+###### Firewall Status and Activation
+
+The firewall MUST be enabled and running to enforce security rules.
+
+On Ubuntu/Debian/Arch:
+
+    > sudo ufw status
+    Status: active
+
+    > sudo ufw enable        # if inactive
+
+On Rocky/Fedora/RHEL/OpenSUSE:
+
+    > sudo firewall-cmd --state
+    running
+
+    > sudo systemctl enable --now firewalld   # if not running
+
+### Default Policy Hardening
+
+A secure system follows the *Fail-Safe Default* principle: everything not explicitly permitted is denied.
+
+- **Incoming Traffic**: MUST be set to *deny*. This prevents other devices or attackers from initiating connections to your computer.
+
+  On Ubuntu/Debian/Arch (UFW):
+
+      sudo ufw default deny incoming
+
+  On Rocky/Fedora/RHEL/OpenSUSE (firewalld):
+
+      sudo firewall-cmd --set-default-zone=drop --permanent
+      sudo firewall-cmd --reload
+
+- **Outgoing Traffic**: For personal use, this is typically set to *allow* so that browsers, updates, and applications can function without manual intervention.
+
+  On Ubuntu/Debian/Arch (UFW):
+
+      sudo ufw default allow outgoing
+
+### Reviewing and Removing Rules
+
+Every open port is a potential entry point for attackers. If you have previously opened ports, review and remove them regularly.
+
+On Ubuntu/Debian/Arch (UFW):
+
+    > sudo ufw status numbered
+    Status: active
+
+    #     To                         Action      From
+    #[ 1] 80/tcp                     ALLOW IN    Anywhere
+
+    > sudo ufw delete 1     # remove rule no longer needed
+
+On Rocky/Fedora/RHEL/OpenSUSE (firewalld):
+
+    > sudo firewall-cmd --list-all
+    > sudo firewall-cmd --remove-service=http --permanent
+    > sudo firewall-cmd --reload
+
+- **Note**: Always maintain a minimal ruleset. If you do not explicitly host a service, your ruleset should ideally be empty, relying entirely on the *default deny* policy.
+
+## Configure TCP Wrappers and Hosts Access
+
+TCP Wrappers provide a host-based access control system for services compiled against the `libwrap.so` library. While most modern access control is handled by dedicated host firewalls (e.g., UFW/nftables), TCP Wrappers remain relevant as a secondary, service-specific security layer for compatible services like `sshd`, `vsftpd`, and `telnetd`.
+
+> **Warning (lockout risk):** This control can prevent you from logging in or from reaching the system over the network. Apply it under the *Session Safety Protocol* described in Phase 0.
+
+### Enforcement of Default Deny Policy
+
+The security configuration MUST follow the principle of *Default Deny*. This is achieved by explicitly allowing only known good connections in `/etc/hosts.allow` and then denying everything else in `/etc/hosts.deny`.
+
+The `/etc/hosts.deny` file MUST contain a blanket rule to deny all access to all wrapped services:
+
+    ALL: ALL
+
+This ensures that any service linked against the library will deny a connection unless an explicit rule in `/etc/hosts.allow` overrides it.
+
+To implement this mandatory deny rule:
+
+    > echo 'ALL: ALL' | sudo tee /etc/hosts.deny
+
+### Configuring Explicit Allow Rules
+
+The `/etc/hosts.allow` file is where authorized services and hosts MUST be explicitly listed. The format is `daemon_list: client_list`.
+
+For example, to allow SSH access for all users coming from the local network (`192.168.1.0/24`) and a specific administrative host (`10.10.10.5`):
+
+    sshd: 192.168.1. 10.10.10.5
+
+> **Note:** You MUST define all necessary allow rules in `/etc/hosts.allow` before implementing the `ALL: ALL` deny rule in `/etc/hosts.deny`. Failure to do so will result in an immediate remote administrative lockout for the affected services. *Client systems* (workstations, endpoints) that do not require inbound SSH access MUST NOT add any `sshd` entry to `/etc/hosts.allow`. The blanket `ALL: ALL` deny rule in `/etc/hosts.deny` will then block all SSH connection attempts without any additional configuration.
+
+### Setting Restrictive Permissions
+
+The integrity of the access control files is paramount. They MUST be protected against unauthorized modification. Permissions SHOULD be set to 0644, ensuring only the root user can write to the files.
+
+To enforce the required permissions:
+
+    > sudo chmod 0644 /etc/hosts.allow
+    > sudo chmod 0644 /etc/hosts.deny
+
+### Verification of Service Linkage
+
+To determine if a specific service is utilizing TCP Wrappers, you can check if the executable is linked against the `libwrap.so` library using the `ldd` utility.
+
+Example check for the SSH daemon:
+
+    > ldd /usr/sbin/sshd | grep libwrap
+        libwrap.so.0 => /lib/x86_64-linux-gnu/libwrap.so.0 (0x00007f1f91b79000)
+
+If the `libwrap.so` library is present in the output, the service respects the rules defined in `/etc/hosts.allow` and `/etc/hosts.deny`.
+
+# Phase 8: Time, Logging and Auditing
+
+Time synchronisation comes first in this phase and not later, because every control that follows writes timestamps. Logs from a machine with a drifting clock cannot be correlated with anything else and are close to worthless as evidence. The audit rules are then loaded, and the configuration is made immutable only at the very end. Once immutable, the rules cannot be changed again without a reboot.
+
+## Secure Time Synchronization (Chrony)
+
+Accurate time synchronization is mandatory for security. Reliable timestamps are critical for audit trails, log analysis, and authentication protocols such as Kerberos or TLS certificate validation. Time drift can render logs useless and break client authentication. Chrony is the preferred modern implementation over the legacy NTP daemon (ntpd).
+
+### Necessity of Time Synchronization
+
+The system must maintain time synchronized with an authoritative external source. A deviation from real-world time should not exceed one minute, although best practice is to limit drift to a few seconds to ensure logs from different systems remain correlated.
+
+###### Enforce Least Privileges
+
+The time synchronization daemon must run as a dedicated, unprivileged user (typically chrony or ntp). This limits the extent of damage if the daemon were to be compromised. Modern distributions configure this separation by default via the systemd unit file.
+
+To confirm the current user under which the daemon is running:
+
+    > ps -eo user,comm | grep chronyd
+
+The output must show the process owned by a non-root user.
+
+###### Restrict Network Access
+
+The command and control interface for Chrony (chronyc) allows administrators to monitor and adjust the daemon. This interface must be restricted to the loopback interface (`127.0.0.1` and `::1`) to prevent external users from querying or manipulating the service.
+
+The configuration file `/etc/chrony/chrony.conf` must contain:
+
+    bindcmdaddress 127.0.0.1
+    bindcmdaddress ::1
+
+If the system must act as a time server for an internal network, the `allow` directive should be used to restrict client access to that specific subnet only.
+
+###### Implement Network Time Security (NTS)
+
+Traditional NTP is vulnerable to Machine-in-the-Middle (MitM) attacks, where attackers can supply false time to the client. This can be used to bypass security features like certificate expiration checks. Network Time Security (NTS) is the modern standard and must be used whenever possible to cryptographically authenticate the time source using TLS.
+
+To use NTS, the configuration file requires specific servers and the nts option:
+
+    server nts.example.com iburst nts
+
+##### Implementation Procedure
+
+To apply the security configuration persistently, update the Chrony configuration and restart the service:
+
+    # Restrict command interface to localhost
+    > sudo tee -a /etc/chrony/chrony.conf <<EOF
+    bindcmdaddress 127.0.0.1
+    bindcmdaddress ::1
+    EOF
+
+    # Note: Ensure at least one NTS-capable server is added to /etc/chrony/chrony.conf
+    # Example: server nts.ntp.se iburst nts
+
+    # Apply changes
+    > sudo systemctl restart chronyd
+
+## Systemd Journal Hardening and Integrity
+
+The `systemd-journald` daemon manages a structured, indexed log system that is the primary logging facility on modern Linux distributions. Security hardening is mandatory to ensure log integrity, retention, and restricted access.
+
+### Enforcing Persistent Storage (Forensic Integrity)
+
+By default, some distributions set `Storage=auto` or `Storage=volatile`, which means logs are stored in `/run/log/journal` and cleared on reboot. For security and forensic integrity, logs MUST persist across reboots.
+
+Set the `Storage` parameter to persistent in `/etc/systemd/journald.conf`:
+
+    Storage=persistent
+
+This configuration ensures that logs are stored in `/var/log/journal`, which survives system reboots.
+
+### Enabling Compression
+
+To prevent log files from unnecessarily consuming large amounts of disk space, especially on high-volume systems, compression SHOULD be enabled.
+
+Set the `Compress` parameter to yes in `/etc/systemd/journald.conf`:
+
+    Compress=yes
+
+### Log Forwarding to Traditional Syslog
+
+If the system utilizes a traditional syslog daemon (`rsyslog` or `syslog-ng`) for centralized log aggregation (SIEM), the journal MUST be configured to forward copies of all messages.
+
+Set the `ForwardToSyslog` parameter to yes in `/etc/systemd/journald.conf`:
+
+    ForwardToSyslog=yes
+
+### Protecting Persistent Log Directory
+
+The persistent log directory (`/var/log/journal`) contains sensitive data and MUST be protected with restrictive permissions. The directory owner (root) and group (`systemd-journal`) are the only entities that should have write access. The SetGID (2) bit MUST be set on the directory to ensure that new files created within it inherit the `systemd-journal` group ownership.
+
+The permissions MUST be set to `2755` (rwxr-xr-x with SetGID bit):
+
+    > sudo chmod 2755 /var/log/journal
+
+###### Applying Changes
+
+After modifying `/etc/systemd/journald.conf`, the `journald` daemon MUST be restarted:
+
+    > sudo systemctl restart systemd-journald
+
+## Syslog Daemon Hardening
+
+System logs contain critical forensic evidence, sensitive authentication attempts, and information about the system's state. Hardening the Syslog daemon (commonly `rsyslog` or `syslog-ng`) is mandatory to ensure the confidentiality and integrity of this data, and to prevent the daemon itself from becoming an attack vector.
+
+### Disable Network Listening (Attack Surface Reduction)
+
+If the host is not intended to act as a centralized log collector, the Syslog daemon MUST NOT listen on any network sockets. Listening on UDP port 514 or TCP port 601 exposes the daemon to remote attacks, including Denial of Service (DoS) and potential overflows.
+
+Verify that network receiver modules are disabled in the daemon's configuration file (e.g., `/etc/rsyslog.conf`). The following lines MUST be commented out or removed:
+
+    # $ModLoad imudp
+    # $UDPServerRun 514
+    # $ModLoad imtcp
+    # $InputTCPServerRun 601
+
+After modifying the configuration file, the daemon MUST be restarted to apply the change:
+
+    > sudo systemctl restart rsyslog
+
+### Restrict Log File Permissions (Confidentiality)
+
+Critical log files MUST be protected from unauthorized reading by unprivileged users. This is especially true for logs containing authentication data (`auth.log`), mail logs, and kernel messages.
+
+Permissions MUST be set to `0640` (Read/Write for owner, Read for group, no access for others) or tighter. The log files are typically owned by `root:adm` or `syslog:adm`.
+
+The following command MUST be run for all critical logs, particularly `auth.log`:
+
+    > sudo chmod 0640 /var/log/auth.log
+
+To verify the permission:
+
+    > stat -c "%a" /var/log/auth.log
+    640
+
+### Secure Remote Forwarding
+
+If the host MUST forward logs to a centralized server (SIEM), plaintext transmission over UDP/TCP is strictly prohibited. Logging MUST utilize a secure, authenticated transport protocol, such as RELP (Reliable Event Logging Protocol) or TLS/SSL encryption over TCP.
+
+Example configuration for TLS-encrypted forwarding (rsyslog):
+
+    # Use reliable TCP forwarding with encryption
+    $ActionSendStreamDriverMode 1   # Use TLS
+    $ActionSendStreamDriverAuthMode anon
+    $ActionSendStreamDriverPermittedPeer log_collector.example.com
+    *.* @@log_collector.example.com:6514
 
 ## Audit Framework Installation and Setup
 
@@ -2153,6 +2603,8 @@ This command loads the configuration without requiring a system reboot.
 
 After successfully configuring all necessary audit rules, the configuration MUST be protected against tampering by attackers gaining root privileges. Without protection, attackers could simply run `sudo auditctl -D` (delete all rules) and then proceed with their attack undetected.
 
+> **Warning (irreversible until reboot):** Once the audit configuration is immutable, the rules cannot be changed or cleared without restarting the system. Apply this only after every other control in Phase 8 has been verified.
+
 The concept of immutable audit configuration locks the ruleset in the kernel, making it impossible to modify or clear the rules without a system reboot. This is a mandatory control to guarantee the forensic integrity of the system.
 
 ###### Configuration
@@ -2189,95 +2641,118 @@ The output `enabled 2` confirms the immutable status. If the status is `enabled 
 
 > **Note:** Because the rules cannot be changed until the next reboot, you MUST verify that your entire ruleset is correct and does not excessively log non-security relevant data *before* setting this flag. Excessive logging can lead to a Denial of Service (DoS) by filling the disk partition.
 
-## Syslog Daemon Hardening
+# Phase 9: Runtime Confinement
 
-System logs contain critical forensic evidence, sensitive authentication attempts, and information about the system's state. Hardening the Syslog daemon (commonly `rsyslog` or `syslog-ng`) is mandatory to ensure the confidentiality and integrity of this data, and to prevent the daemon itself from becoming an attack vector.
+With the system configured and audited, confine what runs on it. These controls are placed last because they are the most likely to interfere with day-to-day use, and because diagnosing that interference requires the logging from Phase 8 to already be in place.
 
-### Disable Network Listening (Attack Surface Reduction)
+## Mandatory Access Control (MAC) Implementation
 
-If the host is not intended to act as a centralized log collector, the Syslog daemon MUST NOT listen on any network sockets. Listening on UDP port 514 or TCP port 601 exposes the daemon to remote attacks, including Denial of Service (DoS) and potential overflows.
+Mandatory Access Control (MAC) is your system's second line of defense. While standard permissions allow you to control your own files, MAC enforces a global security policy that even the `root` user must follow. It prevents compromised applications from reaching into parts of the system they don't need.
 
-Verify that network receiver modules are disabled in the daemon's configuration file (e.g., `/etc/rsyslog.conf`). The following lines MUST be commented out or removed:
+### SELinux (Security-Enhanced Linux)
 
-    # $ModLoad imudp
-    # $UDPServerRun 514
-    # $ModLoad imtcp
-    # $InputTCPServerRun 601
+Predominantly found on Fedora and RHEL-based systems, SELinux labels every file, process, and port with a security context. It is incredibly powerful but can be strict.
 
-After modifying the configuration file, the daemon MUST be restarted to apply the change:
+- **Enforcement**: Your system MUST be in Enforcing mode to provide actual protection. Permissive mode only logs violations without blocking them.
 
-    > sudo systemctl restart rsyslog
+- **Verification**: Check your status with:
 
-### Restrict Log File Permissions (Confidentiality)
+      > getenforce
+      Enforcing
 
-Critical log files MUST be protected from unauthorized reading by unprivileged users. This is especially true for logs containing authentication data (`auth.log`), mail logs, and kernel messages.
+> **Note**: If you are experiencing weird "Permission Denied" errors despite having the right file permissions, check `/var/log/audit/audit.log`. It is likely SELinux doing its job.
 
-Permissions MUST be set to `0640` (Read/Write for owner, Read for group, no access for others) or tighter. The log files are typically owned by `root:adm` or `syslog:adm`.
+### AppArmor (Application Armor)
 
-The following command MUST be run for all critical logs, particularly `auth.log`:
+AppArmor is the standard for Ubuntu, Debian, and SUSE. It uses profiles attached to specific applications to restrict their capabilities based on their installation path.
 
-    > sudo chmod 0640 /var/log/auth.log
+- **Arch Linux Support**: While Arch Linux does not enable a MAC by default, it fully supports AppArmor. You can install the `apparmor` package and add `lsm=landlock,lockdown,yama,apparmor,bpf` to your kernel parameters to enable it.
 
-To verify the permission:
+> **Note**: If you use Burp Suite Professional, AppArmor's default profiles for `unprivileged_userns_clone` might break the built-in Chromium browser. You may need to create an exception or a specific profile for it.
 
-    > stat -c "%a" /var/log/auth.log
-    640
+### Mode Selection and Testing
 
-### Secure Remote Forwarding
+MAC frameworks can be disruptive if enabled blindly.
 
-If the host MUST forward logs to a centralized server (SIEM), plaintext transmission over UDP/TCP is strictly prohibited. Logging MUST utilize a secure, authenticated transport protocol, such as RELP (Reliable Event Logging Protocol) or TLS/SSL encryption over TCP.
+- **Monitoring**: Before going full *Enforcing*, run your system in *Permissive* (SELinux) or *Complain* (AppArmor) mode for a few days. This allows you to identify which of your personal apps might need custom rules.
 
-Example configuration for TLS-encrypted forwarding (rsyslog):
+- **Persistence**: Ensure your settings are saved in `/etc/selinux/config` or that the AppArmor service is enabled:
 
-    # Use reliable TCP forwarding with encryption
-    $ActionSendStreamDriverMode 1   # Use TLS
-    $ActionSendStreamDriverAuthMode anon
-    $ActionSendStreamDriverPermittedPeer log_collector.example.com
-    *.* @@log_collector.example.com:6514
+      > sudo systemctl enable --now apparmor
 
-## Systemd Journal Hardening and Integrity
+> **Note**: MAC is not a replacement for good file permissions, but a safety net for when an application's own security fails.
 
-The `systemd-journald` daemon manages a structured, indexed log system that is the primary logging facility on modern Linux distributions. Security hardening is mandatory to ensure log integrity, retention, and restricted access.
+[^1]: Key words for use in RFCs to Indicate Requirement Levels: <https://datatracker.ietf.org/doc/html/rfc2119>
 
-### Enforcing Persistent Storage (Forensic Integrity)
+[^2]: <https://man7.org/linux/man-pages/man8/pwconv.8.html>
 
-By default, some distributions set `Storage=auto` or `Storage=volatile`, which means logs are stored in `/run/log/journal` and cleared on reboot. For security and forensic integrity, logs MUST persist across reboots.
+[^3]: <https://www.enisa.europa.eu/sites/default/files/2025-06/ENISA_Technical_implementation_guidance_on_cybersecurity_risk_management_measures_version_1.0.pdf>, page 142
 
-Set the `Storage` parameter to persistent in `/etc/systemd/journald.conf`:
+[^4]: <https://pages.nist.gov/800-63-4/sp800-63b.html#passwordver>
 
-    Storage=persistent
+[^5]: <https://meltdownattack.com/>
 
-This configuration ensures that logs are stored in `/var/log/journal`, which survives system reboots.
+[^6]: <https://mdsattacks.com/>
 
-### Enabling Compression
+## Systemd Service Sandboxing and Resource Control
 
-To prevent log files from unnecessarily consuming large amounts of disk space, especially on high-volume systems, compression SHOULD be enabled.
+`systemd` provides robust sandboxing features for system services. These features MUST be utilized to implement least privileges and attack surface reduction, minimizing potential damage if a service is compromised.
 
-Set the `Compress` parameter to yes in `/etc/systemd/journald.conf`:
+The best practice is to use configuration override directories (e.g., `/etc/systemd/system/<service>.service.d/`) to apply hardening without altering the original distribution files.
 
-    Compress=yes
+### Protect System Directories (`ProtectSystem`)
 
-### Log Forwarding to Traditional Syslog
+This setting mounts core OS directories as read-only. This defends against compromised services attempting to modify system binaries or configuration.
 
-If the system utilizes a traditional syslog daemon (`rsyslog` or `syslog-ng`) for centralized log aggregation (SIEM), the journal MUST be configured to forward copies of all messages.
+| Value | Description |
+| :--- | :--- |
+| `no` | No protection; allows write access to `/usr`, `/etc`, etc. |
+| `yes` | Read-only mounts `/usr` and `/boot`. |
+| `full` | Read-only mounts `/usr`, `/boot`, and `/etc`. |
+| `strict` | MANDATORY: Entire file system hierarchy is read-only, except for API file systems. |
 
-Set the `ForwardToSyslog` parameter to yes in `/etc/systemd/journald.conf`:
+For critical services, `ProtectSystem` MUST be set to `strict`:
 
-    ForwardToSyslog=yes
+    [Service]
+    ProtectSystem=strict
 
-### Protecting Persistent Log Directory
+### Protect User Home Directories (`ProtectHome`)
 
-The persistent log directory (`/var/log/journal`) contains sensitive data and MUST be protected with restrictive permissions. The directory owner (root) and group (`systemd-journal`) are the only entities that should have write access. The SetGID (2) bit MUST be set on the directory to ensure that new files created within it inherit the `systemd-journal` group ownership.
+This makes user home directories (`/home`, `/root`) inaccessible. A compromised web server should never have the ability to read private user files.
 
-The permissions MUST be set to `2755` (rwxr-xr-x with SetGID bit):
+    [Service]
+    ProtectHome=yes
 
-    > sudo chmod 2755 /var/log/journal
+If a service requires access to specific paths, exceptions can be made using `ReadOnlyPaths` or `ReadWritePaths`.
 
-###### Applying Changes
+### Isolate Temporary Storage (`PrivateTmp`)
 
-After modifying `/etc/systemd/journald.conf`, the `journald` daemon MUST be restarted:
+`PrivateTmp` mounts a private, ephemeral instance of `/tmp` and `/var/tmp` for the service. These are destroyed when the service stops. This prevents the service from manipulating or reading temporary files used by other users or processes.
 
-    > sudo systemctl restart systemd-journald
+    [Service]
+    PrivateTmp=true
+
+### Applying Overrides
+
+Hardening is implemented by creating a file (e.g., `hardening.conf`) in the service's override directory.
+
+Example for `sshd.service`:
+
+1.  Create the directory: `> sudo mkdir -p /etc/systemd/system/sshd.service.d`.
+
+2.  Create the override file: `> sudo nano /etc/systemd/system/sshd.service.d/hardening.conf`.
+
+###### Example Content
+
+    [Service]
+    ProtectSystem=strict
+    ProtectHome=yes
+    PrivateTmp=true
+
+Apply the changes:
+
+    > sudo systemctl daemon-reload
+    > sudo systemctl restart sshd
 
 ## Cron Security
 
@@ -2340,111 +2815,192 @@ The remediation command to achieve this state is:
     > sudo chmod 0640 /etc/at.allow
     > sudo chown root:root /etc/at.allow
 
-## Systemd Service Sandboxing and Resource Control
+## Session and Screen Lock Hardening
 
-`systemd` provides robust sandboxing features for system services. These features MUST be utilized to implement least privileges and attack surface reduction, minimizing potential damage if a service is compromised.
+An unattended, unlocked workstation gives anyone walking past it the logged-in user's full session. The graphical session MUST therefore lock automatically after a short period of inactivity.
 
-The best practice is to use configuration override directories (e.g., `/etc/systemd/system/<service>.service.d/`) to apply hardening without altering the original distribution files.
+### Graphical Screen Lock (GUI)
 
-### Protect System Directories (`ProtectSystem`)
+On desktop systems, a shell timeout only closes the terminal window, leaving the rest of the desktop accessible. Therefore, the graphical session MUST be configured to lock automatically after 5 minutes of inactivity.
 
-This setting mounts core OS directories as read-only. This defends against compromised services attempting to modify system binaries or configuration.
+###### System-wide Enforcement (GNOME)
 
-| Value | Description |
-| :--- | :--- |
-| `no` | No protection; allows write access to `/usr`, `/etc`, etc. |
-| `yes` | Read-only mounts `/usr` and `/boot`. |
-| `full` | Read-only mounts `/usr`, `/boot`, and `/etc`. |
-| `strict` | MANDATORY: Entire file system hierarchy is read-only, except for API file systems. |
+To prevent users from disabling the screen lock, create a *dconf* profile:
 
-For critical services, `ProtectSystem` MUST be set to `strict`:
+1.  **Create the settings file:** `/etc/dconf/db/local.d/00-security-settings`
 
-    [Service]
-    ProtectSystem=strict
+<!-- -->
 
-### Protect User Home Directories (`ProtectHome`)
+    [org/gnome/desktop/session]
+    idle-delay=uint32 300
 
-This makes user home directories (`/home`, `/root`) inaccessible. A compromised web server should never have the ability to read private user files.
+    [org/gnome/desktop/screensaver]
+    lock-enabled=true
 
-    [Service]
-    ProtectHome=yes
+1.  **Lock the settings (Prevent user override):** `/etc/dconf/db/local.d/locks/session`
 
-If a service requires access to specific paths, exceptions can be made using `ReadOnlyPaths` or `ReadWritePaths`.
+<!-- -->
 
-### Isolate Temporary Storage (`PrivateTmp`)
+    /org/gnome/desktop/session/idle-delay
+    /org/gnome/desktop/screensaver/lock-enabled
 
-`PrivateTmp` mounts a private, ephemeral instance of `/tmp` and `/var/tmp` for the service. These are destroyed when the service stops. This prevents the service from manipulating or reading temporary files used by other users or processes.
+###### Apply Changes
 
-    [Service]
-    PrivateTmp=true
+    > sudo dconf update
 
-### Applying Overrides
+### Summary of Controls
 
-Hardening is implemented by creating a file (e.g., `hardening.conf`) in the service's override directory.
+| Scope | Mechanism | Target Value | Effect |
+| :--- | :--- | :--- | :--- |
+| *GUI* | *idle-delay* | *300s* | Activates screensaver/blank screen. |
+| *GUI* | *lock-enabled* | *true* | Requires password to resume session. |
 
-Example for `sshd.service`:
+> **Note**: These settings do not interfere with long-running background tasks such as compile jobs, only with interactive user engagement.
 
-1.  Create the directory: `> sudo mkdir -p /etc/systemd/system/sshd.service.d`.
+###### On Shell Session Timeouts (`TMOUT`)
 
-2.  Create the override file: `> sudo nano /etc/systemd/system/sshd.service.d/hardening.conf`.
+A `TMOUT` value in `/etc/profile.d/` that terminates idle shells is a common item in
+server hardening baselines. It is deliberately **not** required here.
 
-###### Example Content
+On a server, an idle shell is an exposed session: it may be an SSH connection on an
+unattended terminal, reachable by anyone with access to that screen. On a client, the
+terminal lives *inside* the graphical session, so the screen lock above already denies
+access to it. The shell timeout adds no protection that `lock-enabled` does not already
+provide.
 
-    [Service]
-    ProtectSystem=strict
-    ProtectHome=yes
-    PrivateTmp=true
+It does add cost. Set as `readonly TMOUT`, it cannot be overridden even with good reason,
+and it closes idle shells inside `tmux` and `screen`, terminals left at a prompt while a
+build runs elsewhere, and open editor or REPL sessions. On a workstation this is a daily
+irritation in exchange for no additional protection, and irritating controls get worked
+around.
 
-Apply the changes:
+If you are applying this guide to a server rather than a client, add it:
 
-    > sudo systemctl daemon-reload
-    > sudo systemctl restart sshd
+    > sudo tee /etc/profile.d/90-tmout.sh <<'EOF'
+    TMOUT=300
+    export TMOUT
+    readonly TMOUT
+    EOF
 
-## Mandatory Access Control (MAC) Implementation
+## Install and Configure USBGuard
 
-Mandatory Access Control (MAC) is your system's second line of defense. While standard permissions allow you to control your own files, MAC enforces a global security policy that even the `root` user must follow. It prevents compromised applications from reaching into parts of the system they don't need.
+> **Warning (lockout risk):** USBGuard can block a USB keyboard, including the one you are typing on. Generate the policy with all required peripherals connected, and follow the *Session Safety Protocol* in Phase 0: start the service without enabling it, and enable it at boot only once the policy has been tested.
 
-### SELinux (Security-Enhanced Linux)
 
-Predominantly found on Fedora and RHEL-based systems, SELinux labels every file, process, and port with a security context. It is incredibly powerful but can be strict.
+USBGuard is a framework that allows you to control which USB devices are permitted to interact with your system. By default, Linux allows any plugged-in USB device to function, which creates risks such as BadUSB attacks, unauthorized data exfiltration, or the installation of malicious software.
 
-- **Enforcement**: Your system MUST be in Enforcing mode to provide actual protection. Permissive mode only logs violations without blocking them.
+The USBGuard service MUST be installed, configured with a restrictive policy, and actively running to mitigate these physical security risks.
 
-- **Verification**: Check your status with:
+> **Note:** USBGuard MUST NOT be started without a valid policy in place. Starting the service without a configured ruleset can block input devices such as keyboard and mouse, rendering the system unresponsive. Always generate and verify a baseline policy before starting the service.
 
-      > getenforce
-      Enforcing
+###### Installation
 
-> **Note**: If you are experiencing weird "Permission Denied" errors despite having the right file permissions, check `/var/log/audit/audit.log`. It is likely SELinux doing its job.
+The `usbguard` package MUST be installed using your distribution's package manager before proceeding.
 
-### AppArmor (Application Armor)
+###### Policy Configuration (`rules.conf`)
 
-AppArmor is the standard for Ubuntu, Debian, and SUSE. It uses profiles attached to specific applications to restrict their capabilities based on their installation path.
+A secure USBGuard policy follows the principle of least privilege, using a whitelist model: only explicitly authorized devices are allowed; all others are implicitly blocked.
 
-- **Arch Linux Support**: While Arch Linux does not enable a MAC by default, it fully supports AppArmor. You can install the `apparmor` package and add `lsm=landlock,lockdown,yama,apparmor,bpf` to your kernel parameters to enable it.
+A secure policy consists of two primary components:
 
-> **Note**: If you use Burp Suite Professional, AppArmor's default profiles for `unprivileged_userns_clone` might break the built-in Chromium browser. You may need to create an exception or a specific profile for it.
+1. *Whitelist Rules*: Rules for all devices that are known and necessary (e.g., internal USB hubs, keyboard, mouse).
+2. *Default Block Rule*: A final rule that ensures any unlisted or new devices are denied access.
 
-### Mode Selection and Testing
+###### Generating an Initial Policy
 
-MAC frameworks can be disruptive if enabled blindly.
+The `usbguard` utility can generate a policy based on your currently connected devices. This is the recommended starting point for creating your personal whitelist. Ensure all essential peripherals (keyboard, mouse) are connected before running this command:
 
-- **Monitoring**: Before going full *Enforcing*, run your system in *Permissive* (SELinux) or *Complain* (AppArmor) mode for a few days. This allows you to identify which of your personal apps might need custom rules.
+```sh
+> sudo usbguard generate-policy > /etc/usbguard/rules.conf
+```
 
-- **Persistence**: Ensure your settings are saved in `/etc/selinux/config` or that the AppArmor service is enabled:
+###### Enforcing the Block-by-Default Policy
 
-      > sudo systemctl enable --now apparmor
+The last line of the `/etc/usbguard/rules.conf` file MUST be the generic block rule.
 
-> **Note**: MAC is not a replacement for good file permissions, but a safety net for when an application's own security fails.
+```text
+# The final rule MUST be a block rule to deny all other devices
+block
+```
 
-[^1]: Key words for use in RFCs to Indicate Requirement Levels: <https://datatracker.ietf.org/doc/html/rfc2119>
+### Service Activation
 
-[^2]: <https://man7.org/linux/man-pages/man8/pwconv.8.html>
+Once a valid policy is in place, the service MUST be started and tested before being enabled at boot.
 
-[^3]: <https://www.enisa.europa.eu/sites/default/files/2025-06/ENISA_Technical_implementation_guidance_on_cybersecurity_risk_management_measures_version_1.0.pdf>, page 142
+###### Start for Testing only
 
-[^4]: <https://pages.nist.gov/800-63-4/sp800-63b.html#passwordver>
+```sh
+> sudo systemctl start usbguard
+```
 
-[^5]: <https://meltdownattack.com/>
+Verify that all required devices (keyboard, mouse, and other essential peripherals) continue to function correctly. If a device is blocked, update the policy accordingly before proceeding.
 
-[^6]: <https://mdsattacks.com/>
+###### Verification
+
+```sh
+> sudo systemctl is-active usbguard
+```
+
+###### Enable at Boot (only After Successful Validation)
+
+```sh
+> sudo systemctl enable usbguard
+```
+
+###### Applying Policy Changes
+
+After modifying the configuration at any point, you MUST reload the policy:
+
+```sh
+> sudo usbguard set-policy apply
+```
+
+# Phase 10: Verification and Maintenance
+
+Hardening is a state, not an event. This phase confirms the work and defines what to re-check.
+
+## Confirming the Result
+
+Re-run the full audit and compare it against the baseline captured in Phase 0:
+
+    > ./hardener-linux audit --ruleset ruleset.yaml --all | tee ~/hardening-final.txt
+    > diff ~/hardening-baseline.txt ~/hardening-final.txt
+
+Remaining failures are expected in three cases, and each should be recorded rather than
+forced:
+
+- **Controls that are not applicable.** A workstation with no separate `/var` partition,
+  a BIOS system with no EFI variables, or a machine with the IPv6 stack disabled will
+  report controls that cannot apply to it.
+
+- **Controls deliberately not taken.** `noexec` on `/tmp` and unprivileged user namespace
+  restrictions break real workloads. A documented exception is a legitimate outcome; an
+  undocumented one is drift.
+
+- **Controls requiring physical or manual action.** BIOS passwords and boot order cannot
+  be read from the running OS and always report as outstanding.
+
+## Reboot and Re-verify
+
+Several controls only take effect after a restart: mount options, kernel command line
+parameters, immutable audit mode and module blacklists among them. A hardened system MUST
+be rebooted and audited again before it is considered compliant:
+
+    > sudo reboot
+    > ./hardener-linux audit --ruleset ruleset.yaml --all
+
+A control that passes before a reboot and fails after it was applied to the running system
+but never persisted to configuration. This is the most common silent failure in hardening
+and is the reason the checks in `ruleset.yaml` query the kernel and the live service state
+rather than only reading configuration files.
+
+## Ongoing Maintenance
+
+- **Re-audit after every distribution upgrade.** Package upgrades routinely replace
+  `/etc/pam.d/` files, `sshd_config` and `sysctl` defaults.
+
+- **Re-audit after installing any service.** A newly installed daemon may open ports,
+  add SUID binaries or register a PAM profile.
+
+- **Watch the audit log rather than only the audit report.** The rules loaded in Phase 8
+  detect the changes that a periodic compliance scan would miss between runs.

--- a/operating_system/linux/ruleset.yaml
+++ b/operating_system/linux/ruleset.yaml
@@ -7,6 +7,631 @@ preconditions:
 
 ---
 
+title: Secure BIOS/UEFI Settings
+os: linux
+arch:
+- amd64
+- arm64
+labels:
+- boot
+checksuites:
+- id: bios-password-set
+  description: Verify that a BIOS/UEFI administrator password is set to prevent unauthorized firmware changes.
+  command: |
+    echo 'MANUAL-VERIFICATION-REQUIRED'
+  expected: 'Verified in firmware setup'
+  sudo: false
+  fix: 'Manual action required: Enter the BIOS/UEFI setup utility and set an Administrator Password.'
+  fix_sudo: false
+  affected_file: Firmware
+  post_action: None
+  security_level: high
+  risk_level: low
+  risk_desc: Non-disruptive but critical for preventing firmware-level bypasses.
+- id: secure-boot-enabled
+  description: Ensure Secure Boot is enabled to maintain the cryptographic chain of trust.
+  command: |
+    if command -v mokutil >/dev/null 2>&1; then
+      mokutil --sb-state 2>/dev/null | grep -qiE 'SecureBoot[[:space:]]+(is[[:space:]]+)?enabled' \
+        && { echo 1; exit 0; }
+    fi
+    v=/sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c
+    if [ -r "$v" ]; then
+      od -An -t u1 "$v" 2>/dev/null | awk '{print $NF+0}' | tail -n1
+    else
+      echo 0
+    fi
+  expected: 1
+  sudo: true
+  fix: 'Manual action required: Enter the BIOS/UEFI setup utility and enable Secure Boot.'
+  fix_sudo: false
+  affected_file: Firmware
+  post_action: None
+  security_level: high
+  risk_level: medium
+  risk_desc: May prevent booting if using unsigned custom kernels or drivers.
+- id: boot-order-restricted
+  description: Verify the boot order is restricted to the local disk to prevent external media booting.
+  command: |
+    echo 'MANUAL-VERIFICATION-REQUIRED'
+  expected: 'Verified in firmware setup'
+  sudo: false
+  fix: 'Manual action required: Set the boot order to local hard disk only and disable USB/Network boot.'
+  fix_sudo: false
+  affected_file: Firmware
+  post_action: None
+  security_level: high
+  risk_level: low
+  risk_desc: Prevents unauthorized OS loading from USB; must be temporarily reverted for recovery.
+
+---
+title: Partitioning and Mount Options
+os: linux
+arch:
+- amd64
+- arm64
+labels:
+- filesystem
+checksuites:
+- id: separate-partition-tmp
+  description: Ensure /tmp is a separate filesystem (tmpfs or a dedicated volume) rather than part of the root filesystem.
+  command: |
+    findmnt -n -k -o TARGET /tmp 2>/dev/null | head -n1
+  expected: .+
+  sudo: false
+  fix: 'Manual action required: Add a /tmp entry to /etc/fstab (tmpfs is sufficient and requires no repartitioning), or enable
+    the systemd unit with ''systemctl enable --now tmp.mount''. Default on Fedora/RHEL/Rocky/Arch/openSUSE; NOT default on
+    Debian/Ubuntu.'
+  fix_sudo: true
+  affected_file: /etc/fstab
+  post_action: Reboot, or 'mount /tmp' once the entry exists.
+  security_level: baseline
+  risk_level: medium
+  risk_desc: A tmpfs /tmp is applied without repartitioning. Moving /tmp to a dedicated volume requires repartitioning and
+    carries a high risk of data loss if performed incorrectly.
+- id: mount-options-tmp
+  description: 'Ensure /tmp is mounted with all three restrictive options: nodev, nosuid and noexec.'
+  command: |
+    opts=$(findmnt -n -k -o OPTIONS /tmp 2>/dev/null)
+    [ -n "$opts" ] || { echo 0; exit 0; }
+    ok=1
+    for o in nodev nosuid noexec; do
+      printf '%s' "$opts" | tr ',' '\n' | grep -qx "$o" || ok=0
+    done
+    echo "$ok"
+  expected: 1
+  sudo: false
+  fix: 'Manual action required: Add ''nodev,nosuid,noexec'' to the /tmp entry in /etc/fstab, then run ''sudo mount -o remount
+    /tmp''. On systems using the systemd tmp.mount unit instead of fstab, apply the options via ''systemctl edit tmp.mount''
+    ([Mount] Options=mode=1777,strictatime,nosuid,nodev,noexec).'
+  fix_sudo: true
+  affected_file: /etc/fstab
+  post_action: sudo mount -o remount /tmp
+  security_level: baseline
+  risk_level: medium
+  risk_desc: noexec on /tmp breaks DKMS builds, some vendor .run installers, pip source builds and Java applications that unpack
+    native libraries. The correct remedy is to point those processes at a private TMPDIR, not to remove noexec.
+- id: mount-options-dev-shm
+  description: 'Ensure /dev/shm is mounted with all three restrictive options: nodev, nosuid and noexec.'
+  command: |
+    opts=$(findmnt -n -k -o OPTIONS /dev/shm 2>/dev/null)
+    [ -n "$opts" ] || { echo 0; exit 0; }
+    ok=1
+    for o in nodev nosuid noexec; do
+      printf '%s' "$opts" | tr ',' '\n' | grep -qx "$o" || ok=0
+    done
+    echo "$ok"
+  expected: 1
+  sudo: false
+  fix: 'Manual action required: Add ''tmpfs /dev/shm tmpfs defaults,nodev,nosuid,noexec 0 0'' to /etc/fstab, then run ''sudo
+    mount -o remount /dev/shm''.'
+  fix_sudo: true
+  affected_file: /etc/fstab
+  post_action: sudo mount -o remount /dev/shm
+  security_level: baseline
+  risk_level: low
+  risk_desc: Minimal impact; shared memory rarely requires binary execution.
+- id: separate-partition-home
+  description: OPTIONAL on single-user clients. Ensure /home is a separate filesystem so that user data cannot exhaust the
+    root filesystem and so that nodev/nosuid can be applied to user-writable space.
+  command: |
+    findmnt -n -k -o TARGET /home 2>/dev/null | head -n1
+  expected: .+
+  sudo: false
+  fix: 'Manual action required: Create a dedicated volume for /home. This requires repartitioning and a reboot; it cannot be
+    applied to a running system.'
+  fix_sudo: true
+  affected_file: /etc/fstab
+  post_action: System restart required.
+  security_level: high
+  risk_level: high
+  risk_desc: 'Retrofitting this is repartitioning: it cannot be automated, cannot be rolled back by the tool, and carries
+    a high risk of data loss. The security benefit on a single-user client is small, because nodev and nosuid only block device
+    nodes and SUID binaries, and creating either already requires root. Set at security_level high so that a baseline run
+    skips it; it is worth enforcing on multi-user and server systems, and worth choosing at install time everywhere, but
+    it is not worth repartitioning a working client for.'
+- id: mount-options-home
+  description: Ensure /home is mounted with nodev and nosuid when it is a separate filesystem.
+  command: |
+    opts=$(findmnt -n -k -o OPTIONS /home 2>/dev/null)
+    [ -n "$opts" ] || { echo 1; exit 0; }
+    ok=1
+    for o in nodev nosuid; do
+      printf '%s' "$opts" | tr ',' '\n' | grep -qx "$o" || ok=0
+    done
+    echo "$ok"
+  expected: 1
+  sudo: false
+  fix: 'Manual action required: Add ''nodev,nosuid'' to the /home entry in /etc/fstab, then run ''sudo mount -o remount /home''.
+    Do NOT add noexec.'
+  fix_sudo: true
+  affected_file: /etc/fstab
+  post_action: sudo mount -o remount /home
+  security_level: baseline
+  risk_level: low
+  risk_desc: Blocks SUID binaries and device nodes in user-writable space. No impact on normal user activity. Note that both
+    mknod and setting a SUID bit already require root, so this is defence-in-depth against an attacker who has root, not a
+    barrier against an unprivileged user. Passes when /home is not a separate filesystem, because nosuid cannot be applied
+    to / without breaking sudo, su and passwd.
+- id: separate-partition-var
+  description: OPTIONAL on single-user clients. Ensure /var is a separate filesystem so that application, container and spool
+    data cannot exhaust the root filesystem.
+  command: |
+    findmnt -n -k -o TARGET /var 2>/dev/null | head -n1
+  expected: .+
+  sudo: false
+  fix: 'Manual action required: Create a dedicated volume for /var. Requires repartitioning and a reboot; choose this at
+    install time rather than retrofitting it.'
+  fix_sudo: true
+  affected_file: /etc/fstab
+  post_action: System restart required.
+  security_level: high
+  risk_level: high
+  risk_desc: Repartitioning cannot be automated or rolled back and carries a high risk of data loss. This is an availability
+    control (a full /var must not halt the system) rather than a containment control. Set at security_level high so that a
+    baseline run skips it.
+- id: mount-options-var
+  description: Ensure /var is mounted with nodev and nosuid when it is a separate filesystem.
+  command: |
+    opts=$(findmnt -n -k -o OPTIONS /var 2>/dev/null)
+    [ -n "$opts" ] || { echo 1; exit 0; }
+    ok=1
+    for o in nodev nosuid; do
+      printf '%s' "$opts" | tr ',' '\n' | grep -qx "$o" || ok=0
+    done
+    echo "$ok"
+  expected: 1
+  sudo: false
+  fix: 'Manual action required: Add ''nodev,nosuid'' to the /var entry in /etc/fstab, then run ''sudo mount -o remount /var''.
+    Do NOT add noexec. It breaks package manager maintainer scripts, snapd and container runtimes.'
+  fix_sudo: true
+  affected_file: /etc/fstab
+  post_action: sudo mount -o remount /var
+  security_level: baseline
+  risk_level: low
+  risk_desc: Standard containment measure with no impact on package management.
+- id: mount-options-var-log
+  description: Ensure /var/log is mounted with nodev, nosuid and noexec when it is a separate filesystem.
+  command: |
+    opts=$(findmnt -n -k -o OPTIONS /var/log 2>/dev/null)
+    [ -n "$opts" ] || { echo 1; exit 0; }
+    ok=1
+    for o in nodev nosuid noexec; do
+      printf '%s' "$opts" | tr ',' '\n' | grep -qx "$o" || ok=0
+    done
+    echo "$ok"
+  expected: 1
+  sudo: false
+  fix: 'Manual action required: Add ''nodev,nosuid,noexec'' to the /var/log entry in /etc/fstab, then run ''sudo mount -o remount
+    /var/log''. Ensure the /var/log entry appears after /var in /etc/fstab.'
+  fix_sudo: true
+  affected_file: /etc/fstab
+  post_action: sudo mount -o remount /var/log
+  security_level: baseline
+  risk_level: low
+  risk_desc: No legitimate process executes binaries from the log directory.
+- id: separate-partition-var-log-audit
+  description: Ensure /var/log/audit is a separate filesystem, so that a full audit log cannot halt or suspend the whole system.
+  command: |
+    findmnt -n -k -o TARGET /var/log/audit 2>/dev/null | head -n1
+  expected: .+
+  sudo: false
+  fix: 'Manual action required: Create a dedicated volume for /var/log/audit. Requires repartitioning and a reboot. Relevant
+    on systems where auditd is configured with space_left_action/admin_space_left_action set to halt or single.'
+  fix_sudo: true
+  affected_file: /etc/fstab
+  post_action: System restart required.
+  security_level: high
+  risk_level: high
+  risk_desc: Manual partitioning carries a high risk of data loss if performed incorrectly.
+- id: mount-options-var-tmp
+  description: Ensure /var/tmp is mounted with nodev, nosuid and noexec when it is a separate filesystem.
+  command: |
+    opts=$(findmnt -n -k -o OPTIONS /var/tmp 2>/dev/null)
+    [ -n "$opts" ] || { echo 1; exit 0; }
+    ok=1
+    for o in nodev nosuid noexec; do
+      printf '%s' "$opts" | tr ',' '\n' | grep -qx "$o" || ok=0
+    done
+    echo "$ok"
+  expected: 1
+  sudo: false
+  fix: 'Manual action required: Add ''nodev,nosuid,noexec'' to the /var/tmp entry in /etc/fstab, then run ''sudo mount -o remount
+    /var/tmp''.'
+  fix_sudo: true
+  affected_file: /etc/fstab
+  post_action: sudo mount -o remount /var/tmp
+  security_level: baseline
+  risk_level: low
+  risk_desc: /var/tmp is world-writable and persists across reboots; noexec here is safe.
+- id: mount-options-boot
+  description: Ensure /boot is mounted with nodev, nosuid and noexec when it is a separate filesystem.
+  command: |
+    opts=$(findmnt -n -k -o OPTIONS /boot 2>/dev/null)
+    [ -n "$opts" ] || { echo 1; exit 0; }
+    ok=1
+    for o in nodev nosuid noexec; do
+      printf '%s' "$opts" | tr ',' '\n' | grep -qx "$o" || ok=0
+    done
+    echo "$ok"
+  expected: 1
+  sudo: false
+  fix: 'Manual action required: Add ''nodev,nosuid,noexec'' to the /boot entry in /etc/fstab, then run ''sudo mount -o remount
+    /boot''.'
+  fix_sudo: true
+  affected_file: /etc/fstab
+  post_action: sudo mount -o remount /boot
+  security_level: baseline
+  risk_level: low
+  risk_desc: The bootloader reads this partition before mount flags are enforced, so these options do not affect booting.
+- id: mount-options-boot-efi
+  description: Ensure the EFI System Partition (/boot/efi) is mounted with nodev, nosuid, noexec and umask=0077 on UEFI systems.
+  command: |
+    opts=$(findmnt -n -k -o OPTIONS /boot/efi 2>/dev/null)
+    [ -n "$opts" ] || { echo 1; exit 0; }
+    ok=1
+    for o in nodev nosuid noexec; do
+      printf '%s' "$opts" | tr ',' '\n' | grep -qx "$o" || ok=0
+    done
+    printf '%s' "$opts" | tr ',' '\n' | grep -qxE '(umask|fmask)=0*77' || ok=0
+    printf '%s' "$opts" | tr ',' '\n' | grep -qxE '(umask|dmask)=0*77' || ok=0
+    echo "$ok"
+  expected: 1
+  sudo: false
+  fix: 'Manual action required: Add ''nodev,nosuid,noexec,umask=0077'' to the /boot/efi entry in /etc/fstab, then run ''sudo
+    mount -o remount /boot/efi''.'
+  fix_sudo: true
+  affected_file: /etc/fstab
+  post_action: sudo mount -o remount /boot/efi
+  security_level: baseline
+  risk_level: low
+  risk_desc: Firmware reads the ESP directly and is unaffected by kernel mount flags. Writes by grub-install and fwupd continue
+    to work.
+- id: fstab-verify
+  description: Verify that /etc/fstab is syntactically valid and that every referenced device and mount point resolves, so
+    that the next boot does not drop into the emergency shell.
+  command: |
+    findmnt --verify >/dev/null 2>&1 && echo 1 || echo 0
+  expected: 1
+  sudo: false
+  fix: 'Manual action required: Run ''sudo findmnt --verify --verbose'' and correct the reported entries before rebooting.
+    Stale UUIDs and missing mount points are the usual causes.'
+  fix_sudo: false
+  affected_file: /etc/fstab
+  post_action: None
+  security_level: baseline
+  risk_level: low
+  risk_desc: Read-only validation. Warnings are common on systems using systemd mount units and should be reviewed rather than
+    assumed to be failures.
+- id: 38-fs-05-sticky-bit
+  description: Ensure the Sticky Bit is set on all world-writable directories.
+  command: find / -xdev -type d \( -perm -0002 -a ! -perm -1000 \) | wc -l
+  expected: 0
+  sudo: true
+  fix: find / -xdev -type d \( -perm -0002 -a ! -perm -1000 \) -exec chmod +t {} \;
+  fix_sudo: true
+  affected_file: Multiple Directories
+  post_action: None
+  security_level: baseline
+  risk_level: low
+  risk_desc: Prevents users from deleting each other's files in shared directories.
+
+---
+title: Secure GRUB Bootloader with a Password
+os: linux
+arch:
+- amd64
+- arm64
+labels:
+- boot
+checksuites:
+- id: 37-fs-04-bootloader-password
+  description: Verify the bootloader requires a password for single-user mode. Only applies to GRUB; skipped on systems
+    booting via systemd-boot or rEFInd (common on Arch, and increasingly offered as an option elsewhere), which have no
+    grub.cfg and use a different (currently unaudited) mechanism for boot entry protection.
+  requires_file: /boot/grub/grub.cfg
+  command: |
+    grep -rhi '^[[:space:]]*password_pbkdf2' \
+      /boot/grub/grub.cfg /boot/grub2/grub.cfg /boot/grub/user.cfg /boot/grub2/user.cfg \
+      /etc/grub.d/ 2>/dev/null | wc -l
+  expected: 1
+  expected_op: '>='
+  sudo: true
+  fix: |
+    Manual action required: Run 'grub-mkpasswd-pbkdf2' and configure /etc/grub.d/00_header.
+  fix_sudo: false
+  affected_file: /boot/grub/grub.cfg
+  post_action: None
+  security_level: high
+  risk_level: high
+  risk_desc: Misconfiguration can render the system unbootable or lock out administrators.
+
+---
+title: UEFI Secure Boot Verification
+os: linux
+arch:
+- amd64
+- arm64
+labels:
+- boot
+checksuites:
+- id: secure-boot-active
+  description: Verify that UEFI Secure Boot is enabled and active, ensuring only signed code is executed during the boot process.
+    mokutil ships by default on Ubuntu/Fedora/RHEL-family but is an optional install on Debian, SUSE, and Arch. Only
+    meaningful on UEFI systems; BIOS/legacy-boot VMs are skipped cleanly.
+  requires_command: mokutil
+  requires_file: /sys/firmware/efi
+  command: |
+    command -v mokutil >/dev/null 2>&1 || { echo 0; exit 0; }
+    mokutil --sb-state 2>/dev/null | grep -ciE 'SecureBoot[[:space:]]+(is[[:space:]]+)?enabled' || true
+  expected: 1
+  sudo: false
+  distro:
+    debian:
+      command: |
+        if ! command -v mokutil >/dev/null 2>&1; then echo 1; else mokutil --sb-state | grep -cE 'SecureBoot\s+(is\s+)?enabled'; fi
+  fix: 'Manual action required: Access the system''s UEFI/BIOS firmware settings and change ''Secure Boot'' from Disabled
+    to Enabled. NOTE: Ensure all boot components are signed beforehand.'
+  fix_sudo: true
+  affected_file: System Firmware/UEFI
+  post_action: None
+  security_level: baseline
+  risk_level: high
+  risk_desc: Enabling Secure Boot without using signed kernel modules or bootloaders (e.g., custom or self-compiled kernels)
+    will result in the system being unable to boot.
+- id: secure-boot-user-mode
+  description: Verify that the system is operating in User Mode (not Setup Mode) to ensure that the cryptographic keys are
+    installed and enforcing the signing policy. Only meaningful on UEFI systems; BIOS/legacy-boot VMs are skipped
+    cleanly rather than reported as failures.
+  requires_command: bootctl
+  requires_file: /sys/firmware/efi
+  command: |
+    command -v bootctl >/dev/null 2>&1 || { echo 0; exit 0; }
+    bootctl status 2>/dev/null | grep -cF 'Setup Mode: no' || true
+  expected: 1
+  sudo: false
+  distro:
+    debian:
+      command: |
+        if ! command -v bootctl >/dev/null 2>&1; then echo 1; else bootctl status 2>/dev/null | grep -c 'Setup Mode: no'; fi
+  fix: 'Manual action required: If in Setup Mode, the administrator must install the platform keys (PK, KEK, DB) via the firmware
+    interface or using tools like efitools and transition the system to User Mode.'
+  fix_sudo: true
+  affected_file: System Firmware/UEFI
+  post_action: None
+  security_level: baseline
+  risk_level: low
+  risk_desc: Setup Mode means keys are manageable but not enforced; verifying User Mode is a safety check.
+- id: kernel-sig-enforce
+  description: Verify that the kernel is enforcing module signature checks at runtime, which is required when Secure Boot
+    is active.
+  command: |
+    cat /proc/sys/kernel/module_sig_enforce 2>/dev/null || echo 0
+  expected: 1
+  sudo: false
+  fix: 'Manual action required: If this value is 0 despite Secure Boot being enabled, the kernel may be custom-built without
+    signature enforcement. Recompile the kernel with the appropriate configuration options enabled.'
+  fix_sudo: true
+  affected_file: Kernel runtime status
+  post_action: None
+  security_level: high
+  risk_level: low
+  risk_desc: This check does not alter the system; it only verifies the security state.
+
+---
+
+title: Verify Package Integrity
+os: linux
+arch:
+- amd64
+- arm64
+labels:
+- services
+checksuites:
+- id: aide-package-installed
+  description: Verify that the AIDE binary is present on the system for proactive file integrity monitoring.
+  command: command -v aide >/dev/null 2>&1 && echo 1 || echo 0
+  expected: 1
+  sudo: false
+  fix: 'Manual action required: Install AIDE. Debian/Ubuntu: sudo apt install aide aide-common | RHEL/Rocky/Fedora: sudo
+    dnf install -y aide | OpenSUSE: sudo zypper install -y aide | Arch: sudo pacman -S --noconfirm aide'
+  fix_sudo: false
+  affected_file: N/A
+  post_action: Run 'sudo aideinit' (Debian/Ubuntu) or 'sudo aide --init' (RHEL-family/Arch) to initialize the baseline database.
+  security_level: baseline
+  risk_level: low
+  risk_desc: Installation is low risk; initialization consumes CPU/IO.
+- id: pkg-verify-checksums
+  description: Verify installed package files against original metadata (RPM/Deb/Pacman).
+  command: |
+    if command -v rpm >/dev/null; then sudo rpm -Va | grep -v '^..c' | wc -l;
+    elif command -v debsums >/dev/null; then sudo debsums -c 2>&1 | wc -l;
+    elif command -v pacman >/dev/null; then sudo pacman -Qk | grep -v '0 missing files' | wc -l;
+    else echo 0; fi
+  expected: 0
+  sudo: true
+  fix: 'Manual action required: Review identified files. If they are not intentional configuration changes, reinstall the
+    affected package.'
+  fix_sudo: false
+  affected_file: System-wide
+  post_action: None
+  security_level: high
+  risk_level: medium
+  risk_desc: Manual review is mandatory; reinstallation may disrupt services.
+
+---
+title: CPU Microcode Updates
+os: linux
+arch:
+- amd64
+- arm64
+labels:
+- boot
+checksuites:
+- id: microcode-revision-runtime
+  description: Verify that a non-zero microcode revision (indicating a successful update over the default BIOS version) is
+    loaded in the running CPU.
+  command: |
+    grep -m1 -i 'microcode' /proc/cpuinfo 2>/dev/null | awk '{print $NF}' \
+      | grep -cE '^0x0*[1-9a-fA-F][0-9a-fA-F]*$' || true
+  expected: 1
+  sudo: false
+  fix: 'Manual action required: If the microcode package is installed but this check fails, ensure the initramfs/initrd was
+    updated (e.g., sudo update-initramfs -u) and the system rebooted.'
+  fix_sudo: true
+  affected_file: Kernel runtime status
+  post_action: None
+  security_level: baseline
+  risk_level: low
+  risk_desc: This is a verification check and does not alter the system state.
+- id: vulnerability-mitigation-status
+  description: Verify that the system is reporting successful mitigation for critical hardware vulnerabilities, such as Spectre
+    V2, which requires microcode patches.
+  command: |
+    cat /sys/devices/system/cpu/vulnerabilities/spectre_v2 2>/dev/null \
+      | grep -cE 'Mitigation:|Not affected' || true
+  expected: 1
+  expected_op: '>='
+  sudo: false
+  fix: 'Manual action required: Ensure the microcode package is installed, the kernel is patched, and that all kernel command
+    line parameters are correctly configured.'
+  fix_sudo: true
+  affected_file: Kernel runtime status
+  post_action: None
+  security_level: high
+  risk_level: low
+  risk_desc: This is a verification check and relies on the kernel's ability to report mitigation status.
+
+---
+title: Kernel Command Line Hardening
+os: linux
+arch:
+- amd64
+- arm64
+labels:
+- kernel
+- boot
+checksuites:
+- id: cmdline-mem-protection
+  description: Verify that security-critical kernel parameters (slab_nomerge, vsyscall, pti) are active in the boot configuration.
+  command: cat /proc/cmdline | grep -E 'slab_nomerge|vsyscall=none|pti=on' | wc -l
+  expected: 3
+  sudo: false
+  fix: 'Manual action required: Edit GRUB_CMDLINE_LINUX_DEFAULT in /etc/default/grub to include these parameters and run update-grub.'
+  fix_sudo: true
+  affected_file: /etc/default/grub
+  post_action: Reboot required to apply kernel parameters.
+  security_level: high
+  risk_level: low
+  risk_desc: Improves memory protection with minimal performance impact.
+- id: initramfs-shell-disabled
+  description: Verify that the initramfs debug shell is disabled to prevent unauthorized console access.
+  command: cat /proc/cmdline | grep -E 'panic=0|rd.shell=0' | wc -l
+  expected: 1
+  sudo: false
+  fix: 'Manual action required: Add ''panic=0'' (Debian/Ubuntu) or ''rd.shell=0'' (RHEL/Fedora) to the kernel command line.'
+  fix_sudo: true
+  affected_file: /etc/default/grub
+  post_action: Reboot required.
+  security_level: high
+  risk_level: medium
+  risk_desc: Prevents a bypass to a root shell, but requires live media for troubleshooting boot failures.
+
+---
+title: Protecting Single User Mode
+os: linux
+arch:
+- amd64
+- arm64
+labels:
+- boot
+checksuites:
+- id: rescue-service-authentication
+  description: Ensure authentication is required when entering rescue mode (systemd).
+  command: |
+    grep -E '^ExecStart=.\*sulogin' /usr/lib/systemd/system/rescue.service /lib/systemd/system/rescue.service | wc -l
+  expected: '1'
+  sudo: false
+  fix: 'Manual action required: Create a systemd override for rescue.service to force the use of sulogin.'
+  fix_sudo: true
+  affected_file: /etc/systemd/system/rescue.service.d/override.conf
+  post_action: 'Reload systemd daemon: systemctl daemon-reload'
+  security_level: high
+  risk_level: medium
+  risk_desc: If the root password is lost or forgotten, legitimate administrators will be unable to access rescue mode to
+    recover the system without using a boot loader exploit (init=/bin/bash).
+- id: emergency-service-authentication
+  description: Ensure authentication is required when entering emergency mode (systemd).
+  command: |
+    grep -E '^ExecStart=.\*sulogin' /usr/lib/systemd/system/emergency.service /lib/systemd/system/emergency.service | wc -l
+  expected: '1'
+  sudo: false
+  fix: 'Manual action required: Create a systemd override for emergency.service to force the use of sulogin.'
+  fix_sudo: true
+  affected_file: /etc/systemd/system/emergency.service.d/override.conf
+  post_action: 'Reload systemd daemon: systemctl daemon-reload'
+  security_level: high
+  risk_level: medium
+  risk_desc: If the root password is lost, access to emergency mode will be blocked without external boot media.
+- id: legacy-sysvinit-single-mode
+  description: Ensure authentication is required for single user mode on legacy SysVinit systems (RHEL6/CentOS6 era).
+  command: if [ -f /etc/sysconfig/init ]; then grep '^SINGLE=/sbin/sulogin' /etc/sysconfig/init | wc -l; else echo 1; fi
+  expected: '1'
+  sudo: false
+  fix: Edit /etc/sysconfig/init and set SINGLE=/sbin/sulogin
+  fix_sudo: true
+  affected_file: /etc/sysconfig/init
+  post_action: None
+  security_level: baseline
+  risk_level: low
+  risk_desc: Only applies to legacy systems. Risk is minimal provided the root password is known.
+
+---
+title: Disable Ctrl-Alt-Del Reboot Sequence
+os: linux
+arch:
+- amd64
+- arm64
+labels:
+- boot
+checksuites:
+- id: ctrl-alt-del-masked
+  description: Verify that the Ctrl-Alt-Del reboot sequence is disabled by masking the systemd target.
+  command: |
+    out=$(systemctl is-enabled ctrl-alt-del.target 2>/dev/null)
+    printf '%s\n' "$out" | grep -cx masked || true
+  expected: 1
+  sudo: false
+  fix: sudo ln -sf /dev/null /etc/systemd/system/ctrl-alt-del.target && sudo systemctl daemon-reload
+  fix_sudo: true
+  affected_file: /etc/systemd/system/ctrl-alt-del.target
+  post_action: None
+  security_level: baseline
+  risk_level: low
+  risk_desc: Prevents accidental or unauthorized reboots from the physical keyboard.
+
+---
+
 title: Harden Administrative Accounts
 os: linux
 arch:
@@ -44,263 +669,6 @@ checksuites:
     fails.
 
 ---
-
-title: Check that All Passwords Are Shadowed
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- auth
-checksuites:
-- id: passwords-shadowed
-  description: Verify that all accounts in /etc/passwd have an 'x' in the password field, indicating hashes are stored in
-    /etc/shadow.
-  command: |
-    awk -F: '($2 != "x") {print}' /etc/passwd | wc -l
-  expected: 0
-  sudo: false
-  fix: sudo pwconv
-  fix_sudo: true
-  affected_file: /etc/passwd
-  post_action: None
-  security_level: baseline
-  risk_level: low
-  risk_desc: Modern systems use shadowing by default. If hashes are in /etc/passwd, they are readable by any user, allowing
-    offline cracking.
-
----
-
-title: Use Strong Hashing Algorithm
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- auth
-checksuites:
-- id: 39-auth-01-pass-encryption
-  description: Ensure passwords use SHA512 or better hashing to protect against offline cracking.
-  command: grep -E '^ENCRYPT_METHOD (SHA512|YESCRYPT)' /etc/login.defs | wc -l
-  expected: 1
-  sudo: false
-  fix: sudo sed -i 's/^ENCRYPT_METHOD.*/ENCRYPT_METHOD YESCRYPT/' /etc/login.defs
-  fix_sudo: true
-  affected_file: /etc/login.defs
-  post_action: Existing hashes are not updated automatically. Users MUST change their passwords to migrate to the new algorithm.
-  security_level: baseline
-  risk_level: low
-  risk_desc: Ensures compliance for new accounts and password changes. No risk of lockout.
-
----
-
-title: Password Policy
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- auth
-checksuites:
-- id: pam-stack-integration
-  description: Verify that the pam_pwquality module is actually active in the PAM stack.
-  # Detect the correct PAM file at runtime — /etc/pam.d/system-auth on
-  # RHEL/Rocky/Fedora/Arch, /etc/pam.d/common-password on Debian/Ubuntu/openSUSE.
-  command: |
-    f=/etc/pam.d/system-auth
-    [ -f "$f" ] || f=/etc/pam.d/common-password
-    [ -f "$f" ] || { echo 0; exit 0; }
-    grep -cE '^\s*password\s+requisite\s+pam_pwquality.so' "$f"
-  expected: 1
-  sudo: false
-  fix: 'Manual action required: Ensure ''password requisite pam_pwquality.so'' is present in the password PAM stack. On
-    Debian/Ubuntu/OpenSUSE/SUSE: edit /etc/pam.d/common-password. On RHEL/Rocky/AlmaLinux/Fedora: use ''authselect'' to
-    manage PAM (do not edit /etc/pam.d/system-auth directly — it is managed by authselect). On Arch/Manjaro: edit
-    /etc/pam.d/system-auth. Modifying PAM files via scripts is too hazardous for automated fixing.'
-  fix_sudo: false
-  affected_file: /etc/pam.d/common-password
-  post_action: None
-  security_level: baseline
-  risk_level: high
-  risk_desc: If the module is missing from the stack, settings in pwquality.conf are ignored. Incorrect manual editing may
-    lock out users.
-- id: pass-history
-  description: Prevent password reuse by remembering the last 5 passwords.
-  # Runtime PAM file detection: system-auth on RHEL/Fedora/Arch,
-  # common-password on Debian/Ubuntu/openSUSE.
-  command: |
-    f=/etc/pam.d/system-auth
-    [ -f "$f" ] || f=/etc/pam.d/common-password
-    [ -f "$f" ] || { echo 0; exit 0; }
-    grep -E '^\s*password\s+required\s+pam_pwhistory.so' "$f" | grep -c 'remember=5'
-  expected: 1
-  sudo: true
-  fix: 'Manual action required: Add ''password required pam_pwhistory.so remember=5 enforce_for_root'' to the password
-    PAM stack. On Debian/Ubuntu/OpenSUSE/SUSE: edit /etc/pam.d/common-password. On RHEL/Rocky/AlmaLinux/Fedora: apply via
-    authselect custom profile. On Arch/Manjaro: edit /etc/pam.d/system-auth.'
-  fix_sudo: false
-  affected_file: /etc/pam.d/common-password
-  post_action: None
-  security_level: baseline
-  risk_level: high
-  risk_desc: Required to prevent users from immediately cycling back to a compromised password.
-- id: pam-unix-yescrypt
-  description: Ensure pam_unix is configured to use a strong hashing algorithm (yescrypt preferred; sha512 acceptable where
-    yescrypt is unavailable, e.g. RHEL-family).
-  # Detect the PAM file and accept either algorithm — yescrypt on
-  # Debian/Ubuntu/Arch/openSUSE, sha512 on RHEL/Rocky/Fedora.
-  command: |
-    f=/etc/pam.d/system-auth
-    [ -f "$f" ] || f=/etc/pam.d/common-password
-    [ -f "$f" ] || { echo 0; exit 0; }
-    grep -cE '^\s*password\s+.*pam_unix.so.*(yescrypt|sha512)' "$f"
-  expected: 1
-  sudo: true
-  fix: 'Manual action required: Update the pam_unix.so line to include ''yescrypt'' (preferred) or ''sha512''. On RHEL/Rocky/Fedora
-    manage via authselect rather than editing system-auth directly.'
-  fix_sudo: false
-  affected_file: /etc/pam.d/common-password
-  post_action: Only affects new passwords.
-  security_level: high
-  risk_level: medium
-  risk_desc: Yescrypt provides superior resistance to GPU-based cracking compared to SHA-512. RHEL-family distros do not ship
-    yescrypt support; SHA-512 is the strongest available option there.
-
----
-
-title: Account Lockout (Faillock)
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- auth
-checksuites:
-- id: faillock-unlock-time
-  description: Verify that the account lockout duration is at least 180 seconds.
-  # Runtime PAM file detection — see pam-stack-integration for the rationale.
-  # Note that on RHEL-family the modern place to configure faillock is
-  # /etc/security/faillock.conf via authselect; grepping the PAM stack still
-  # catches directly-edited entries.
-  command: |
-    f=/etc/pam.d/system-auth
-    [ -f "$f" ] || f=/etc/pam.d/common-auth
-    [ -f "$f" ] || { echo 0; exit 0; }
-    grep -cE 'pam_faillock.so.*unlock_time=(18[0-9]|19[0-9]|[2-9][0-9][0-9])' "$f"
-  expected: 2
-  expected_op: '>='
-  sudo: true
-  distro:
-    rocky:
-      command: grep -E 'pam_faillock.so.*unlock_time=(18[0-9]|19[0-9]|[2-9][0-9][0-9])' /etc/pam.d/system-auth | wc -l
-      fix: 'Manual action required: Ensure ''unlock_time=180'' is set for both pam_faillock entries in /etc/pam.d/system-auth.
-        On RHEL/Rocky/Fedora, prefer managing faillock settings via ''authselect'' or /etc/security/faillock.conf.'
-    rhel:
-      command: grep -E 'pam_faillock.so.*unlock_time=(18[0-9]|19[0-9]|[2-9][0-9][0-9])' /etc/pam.d/system-auth | wc -l
-      fix: 'Manual action required: Ensure ''unlock_time=180'' is set for both pam_faillock entries in /etc/pam.d/system-auth.
-        On RHEL/Rocky/Fedora, prefer managing faillock settings via ''authselect'' or /etc/security/faillock.conf.'
-    fedora:
-      command: grep -E 'pam_faillock.so.*unlock_time=(18[0-9]|19[0-9]|[2-9][0-9][0-9])' /etc/pam.d/system-auth | wc -l
-      fix: 'Manual action required: Ensure ''unlock_time=180'' is set for both pam_faillock entries in /etc/pam.d/system-auth.
-        On RHEL/Rocky/Fedora, prefer managing faillock settings via ''authselect'' or /etc/security/faillock.conf.'
-    archlinux:
-      command: grep -E 'pam_faillock.so.*unlock_time=(18[0-9]|19[0-9]|[2-9][0-9][0-9])' /etc/pam.d/system-auth | wc -l
-      fix: 'Manual action required: Ensure ''unlock_time=180'' is set for both pam_faillock entries in /etc/pam.d/system-auth.'
-  fix: 'Manual action required: Ensure ''unlock_time=180'' is set for both pam_faillock entries in /etc/pam.d/common-auth.'
-  fix_sudo: false
-  affected_file: /etc/pam.d/common-auth
-  post_action: None
-  security_level: baseline
-  risk_level: medium
-  risk_desc: A shorter unlock time increases the effectiveness of automated brute-force attacks.
-
----
-
-title: Password & Account Aging
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- auth
-checksuites:
-- id: 41-auth-03-pass-lifetime
-  description: Verify that password maximum age is set to disable legacy rotation (99999 days) in /etc/login.defs.
-  command: grep '^PASS_MAX_DAYS' /etc/login.defs | awk '{if($2>=99999) print 1; else print 0}'
-  expected: 1
-  sudo: false
-  fix: sudo sed -i 's/^PASS_MAX_DAYS.*/PASS_MAX_DAYS 99999/' /etc/login.defs
-  fix_sudo: true
-  affected_file: /etc/login.defs
-  post_action: Existing users must be updated manually via chage.
-  security_level: baseline
-  risk_level: low
-  risk_desc: Prevents password exhaustion and weak patterns caused by frequent forced changes.
-- id: 65-auth-13-pass-min-days
-  description: Ensure a minimum password age of 1 day to prevent rapid cycling through password history.
-  command: grep '^PASS_MIN_DAYS' /etc/login.defs | awk '{if($2>=1) print 1; else print 0}'
-  expected: 1
-  sudo: false
-  fix: sudo sed -i 's/^PASS_MIN_DAYS.*/PASS_MIN_DAYS 1/' /etc/login.defs
-  fix_sudo: true
-  affected_file: /etc/login.defs
-  post_action: None
-  security_level: baseline
-  risk_level: low
-  risk_desc: Low risk. Hinders users from immediately reverting to an old password.
-- id: 66-auth-14-account-inactivity
-  description: Ensure new accounts are disabled 30 days after password expiration (INACTIVE=30).
-  command: useradd -D | grep '^INACTIVE' | cut -d'=' -f2 | grep -q '30' && echo 1 || echo 0
-  expected: 1
-  sudo: false
-  fix: sudo useradd -D -f 30
-  fix_sudo: true
-  affected_file: /etc/default/useradd
-  post_action: None
-  security_level: high
-  risk_level: medium
-  risk_desc: Prevents abandoned accounts from remaining active and vulnerable to takeover.
-
----
-
-title: Restricting Direct Root Login
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- auth
-checksuites:
-- id: 67-auth-15-pam-securetty
-  description: Ensure pam_securetty.so is enabled to restrict root logins to specific terminals.
-  command: |
-    grep -E '^\s*auth\s+required\s+pam_securetty.so' /etc/pam.d/login | wc -l
-  expected: 1
-  sudo: false
-  fix: 'Manual action required: Add ''auth required pam_securetty.so'' to /etc/pam.d/login.'
-  fix_sudo: false
-  affected_file: /etc/pam.d/login
-  post_action: None
-  security_level: high
-  risk_level: medium
-  risk_desc: Ensures root cannot log in from unauthorized TTYs. Risk of lockout if local console access is the only remaining
-    login method.
-- id: 68-auth-16-securetty-config
-  description: Verify that /etc/securetty exists and contains a restricted list of terminals.
-  command: |
-    [ -f /etc/securetty ] && grep -v '^#' /etc/securetty | grep -qv '^\s*$' && echo 1 || echo 0
-  expected: 1
-  sudo: true
-  fix: 'Manual action required: Create /etc/securetty and list only the necessary consoles (e.g., ''console'', ''tty1'').'
-  fix_sudo: false
-  affected_file: /etc/securetty
-  post_action: None
-  security_level: high
-  risk_level: high
-  risk_desc: Improper configuration can block access via the emergency or serial console.
-
----
-
 title: Harden Sudo Usage and Logging
 os: linux
 arch:
@@ -366,8 +734,7 @@ checksuites:
   risk_desc: Prevents unauthorized user switching.
 
 ---
-
-title: Session and Screen Lock Hardening
+title: Check that All Passwords Are Shadowed
 os: linux
 arch:
 - amd64
@@ -375,52 +742,220 @@ arch:
 labels:
 - auth
 checksuites:
-- id: shell-timeout
-  description: Verify that the TMOUT variable is set to 300 seconds or less in global profile configurations.
+- id: passwords-shadowed
+  description: Verify that all accounts in /etc/passwd have an 'x' in the password field, indicating hashes are stored in
+    /etc/shadow.
   command: |
-    grep -rE '^\s*TMOUT=(300|[1-2][0-9][0-9]|[1-9][0-9]|[0-9])' /etc/profile /etc/profile.d/ | wc -l
-  expected: 1
+    awk -F: '($2 != "x") {print}' /etc/passwd | wc -l
+  expected: 0
   sudo: false
-  fix: |
-    echo -e 'TMOUT=300\nexport TMOUT\nreadonly TMOUT' | sudo tee /etc/profile.d/90-tmout.sh
+  fix: sudo pwconv
   fix_sudo: true
-  affected_file: /etc/profile.d/90-tmout.sh
-  post_action: Users must re-login for the change to take effect.
-  security_level: baseline
-  risk_level: low
-  risk_desc: Automatically logs out inactive shells.
-- id: gnome-lock-enabled
-  description: Ensure the GNOME screensaver is configured to lock the screen after a period of inactivity. Only applicable
-    on systems with a GNOME desktop installed (skipped elsewhere) — irrelevant on headless servers regardless of distro,
-    and on Arch/Debian/RHEL-family systems installed without a desktop environment at all.
-  requires_command: gsettings
-  command: gsettings get org.gnome.desktop.screensaver lock-enabled
-  expected: 'true'
-  sudo: false
-  fix: 'Manual action required: Enforce via dconf profile in /etc/dconf/db/local.d/locks/session to prevent user override.'
-  fix_sudo: true
-  affected_file: /etc/dconf/db/local.d/00-security-settings
-  post_action: Run 'sudo dconf update' to apply system-wide changes.
-  security_level: baseline
-  risk_level: low
-  risk_desc: Essential for physical security in desktop environments.
-- id: gnome-idle-delay
-  description: Ensure the GNOME idle delay is set to 300 seconds (5 minutes) or less. Only applicable on systems with a
-    GNOME desktop installed (skipped elsewhere).
-  requires_command: gsettings
-  command: gsettings get org.gnome.desktop.session idle-delay | awk '{if($2<=300 && $2!=0) print 1; else print 0}'
-  expected: 1
-  sudo: false
-  fix: gsettings set org.gnome.desktop.session idle-delay 300
-  fix_sudo: false
-  affected_file: User GSettings Database
+  affected_file: /etc/passwd
   post_action: None
   security_level: baseline
   risk_level: low
-  risk_desc: Mandatory for compliance in office/shared environments.
+  risk_desc: Modern systems use shadowing by default. If hashes are in /etc/passwd, they are readable by any user, allowing
+    offline cracking.
 
 ---
 
+title: Use Strong Hashing Algorithm
+os: linux
+arch:
+- amd64
+- arm64
+labels:
+- auth
+checksuites:
+- id: 39-auth-01-pass-encryption
+  description: Ensure passwords use SHA512 or better hashing to protect against offline cracking.
+  command: grep -E '^ENCRYPT_METHOD (SHA512|YESCRYPT)' /etc/login.defs | wc -l
+  expected: 1
+  sudo: false
+  fix: sudo sed -i 's/^ENCRYPT_METHOD.*/ENCRYPT_METHOD YESCRYPT/' /etc/login.defs
+  fix_sudo: true
+  affected_file: /etc/login.defs
+  post_action: Existing hashes are not updated automatically. Users MUST change their passwords to migrate to the new algorithm.
+  security_level: baseline
+  risk_level: low
+  risk_desc: Ensures compliance for new accounts and password changes. No risk of lockout.
+
+---
+title: Password Policy
+os: linux
+arch:
+- amd64
+- arm64
+labels:
+- auth
+checksuites:
+- id: pam-stack-integration
+  description: Verify that the pam_pwquality module is actually active in the PAM stack.
+  command: |
+    files=""
+    for f in /etc/pam.d/system-auth /etc/pam.d/password-auth /etc/pam.d/common-password; do
+      [ -f "$f" ] && files="$files $f"
+    done
+    [ -n "$files" ] || { echo 0; exit 0; }
+    ok=1
+    for f in $files; do
+      grep -qE '^[[:space:]]*password[[:space:]]+(required|requisite)[[:space:]]+pam_pwquality\.so' "$f" || ok=0
+    done
+    echo "$ok"
+  expected: 1
+  sudo: false
+  fix: 'Manual action required: Ensure ''password requisite pam_pwquality.so'' is present in the password PAM stack. On
+    Debian/Ubuntu/OpenSUSE/SUSE: edit /etc/pam.d/common-password. On RHEL/Rocky/AlmaLinux/Fedora: use ''authselect'' to
+    manage PAM (do not edit /etc/pam.d/system-auth directly, as it is managed by authselect). On Arch/Manjaro: edit
+    /etc/pam.d/system-auth. Modifying PAM files via scripts is too hazardous for automated fixing.'
+  fix_sudo: false
+  affected_file: /etc/pam.d/common-password (Debian/Ubuntu/openSUSE) or /etc/pam.d/system-auth and /etc/pam.d/password-auth
+    (RHEL family, Arch)
+  post_action: None
+  security_level: baseline
+  risk_level: high
+  risk_desc: If the module is missing from the stack, settings in pwquality.conf are ignored. Incorrect manual editing may
+    lock out users.
+- id: pass-history
+  description: Prevent password reuse by remembering at least the last 5 passwords, including for root.
+  command: |
+    files=""
+    for f in /etc/pam.d/system-auth /etc/pam.d/password-auth /etc/pam.d/common-password; do
+      [ -f "$f" ] && files="$files $f"
+    done
+    [ -n "$files" ] || { echo 0; exit 0; }
+    ok=1
+    for f in $files; do
+      grep -E '^[[:space:]]*password[[:space:]]+(required|requisite)[[:space:]]+pam_pwhistory\.so' "$f" \
+        | grep -E 'remember=([5-9]|[1-9][0-9]+)' \
+        | grep -qE 'enforce_for_root' || ok=0
+    done
+    echo "$ok"
+  expected: 1
+  sudo: false
+  fix: 'Manual action required: Add ''password required pam_pwhistory.so remember=5 enforce_for_root use_authtok'' to the
+    password PAM stack, before the pam_unix.so line. On Debian/Ubuntu/OpenSUSE/SUSE: /etc/pam.d/common-password (persist
+    via a profile in /usr/share/pam-configs/, since pam-auth-update overwrites direct edits). On RHEL/Rocky/AlmaLinux/Fedora:
+    apply via an authselect custom profile so that BOTH /etc/pam.d/system-auth and /etc/pam.d/password-auth are updated -
+    these files are symlinks into the authselect profile and must not be edited directly. On Arch/Manjaro: edit /etc/pam.d/system-auth.
+    Also ensure /etc/security/opasswd is root-owned with mode 0600.'
+  fix_sudo: false
+  affected_file: /etc/pam.d/common-password (Debian/Ubuntu/openSUSE) or /etc/pam.d/system-auth and /etc/pam.d/password-auth
+    (RHEL family, Arch)
+  post_action: Takes effect on the next password change. Previous hashes are stored in /etc/security/opasswd.
+  security_level: baseline
+  risk_level: high
+  risk_desc: Required to prevent users from immediately cycling back to a compromised password. Incorrect manual editing of
+    the PAM password stack can lock all users out of password changes.
+- id: pam-password-stack-order
+  description: Verify that pam_pwquality and pam_pwhistory both appear before pam_unix in the password stack, without which
+    neither can reject a password.
+  command: |
+    files=""
+    for f in /etc/pam.d/system-auth /etc/pam.d/password-auth /etc/pam.d/common-password; do
+      [ -f "$f" ] && files="$files $f"
+    done
+    [ -n "$files" ] || { echo 0; exit 0; }
+    ok=1
+    for f in $files; do
+      u=$(grep -nE '^[[:space:]]*password[[:space:]]+.*pam_unix\.so' "$f" 2>/dev/null | head -n1 | cut -d: -f1)
+      [ -n "$u" ] || { ok=0; continue; }
+      for m in pam_pwquality pam_pwhistory; do
+        n=$(grep -nE "^[[:space:]]*password[[:space:]]+.*${m}\.so" "$f" 2>/dev/null | head -n1 | cut -d: -f1)
+        [ -n "$n" ] || { ok=0; continue; }
+        [ "$n" -lt "$u" ] || ok=0
+      done
+    done
+    echo "$ok"
+  expected: 1
+  sudo: false
+  fix: 'Manual action required: Move the pam_pwquality.so and pam_pwhistory.so lines above the pam_unix.so line in the password
+    stack. On Debian/Ubuntu do NOT hand-edit the numeric jump in ''[success=2 default=ignore]'' on the pam_unix line: insert
+    the modules before it, or regenerate the file with pam-auth-update. On RHEL/Rocky/AlmaLinux/Fedora, reorder the templates
+    in an authselect custom profile rather than editing /etc/pam.d directly.'
+  fix_sudo: false
+  affected_file: /etc/pam.d/common-password (Debian/Ubuntu/openSUSE) or /etc/pam.d/system-auth and /etc/pam.d/password-auth
+    (RHEL family, Arch)
+  post_action: Takes effect on the next password change. Test with 'passwd' on a throwaway account before closing your session.
+  security_level: baseline
+  risk_level: high
+  risk_desc: A stack in the wrong order enforces no password policy at all while appearing correctly configured. Reordering
+    PAM modules incorrectly can prevent all password changes and, in the worst case, all logins.
+- id: pam-unix-yescrypt
+  description: Ensure pam_unix is configured to use a strong hashing algorithm (yescrypt preferred; sha512 acceptable where
+    yescrypt is unavailable, e.g. RHEL-family).
+  command: |
+    files=""
+    for f in /etc/pam.d/system-auth /etc/pam.d/password-auth /etc/pam.d/common-password; do
+      [ -f "$f" ] && files="$files $f"
+    done
+    [ -n "$files" ] || { echo 0; exit 0; }
+    ok=1
+    for f in $files; do
+      grep -qE '^[[:space:]]*password[[:space:]]+.*pam_unix\.so.*(yescrypt|sha512)' "$f" || ok=0
+    done
+    echo "$ok"
+  expected: 1
+  sudo: false
+  fix: 'Manual action required: Update the pam_unix.so line to include ''yescrypt'' (preferred) or ''sha512''. On RHEL/Rocky/Fedora
+    manage via authselect rather than editing system-auth directly.'
+  fix_sudo: false
+  affected_file: /etc/pam.d/common-password (Debian/Ubuntu/openSUSE) or /etc/pam.d/system-auth and /etc/pam.d/password-auth
+    (RHEL family, Arch)
+  post_action: Only affects new passwords.
+  security_level: high
+  risk_level: medium
+  risk_desc: Yescrypt provides superior resistance to GPU-based cracking compared to SHA-512. RHEL-family distros do not ship
+    yescrypt support; SHA-512 is the strongest available option there.
+
+---
+title: Password & Account Aging
+os: linux
+arch:
+- amd64
+- arm64
+labels:
+- auth
+checksuites:
+- id: 41-auth-03-pass-lifetime
+  description: Verify that password maximum age is set to disable legacy rotation (99999 days) in /etc/login.defs.
+  command: grep '^PASS_MAX_DAYS' /etc/login.defs | awk '{if($2>=99999) print 1; else print 0}'
+  expected: 1
+  sudo: false
+  fix: sudo sed -i 's/^PASS_MAX_DAYS.*/PASS_MAX_DAYS 99999/' /etc/login.defs
+  fix_sudo: true
+  affected_file: /etc/login.defs
+  post_action: Existing users must be updated manually via chage.
+  security_level: baseline
+  risk_level: low
+  risk_desc: Prevents password exhaustion and weak patterns caused by frequent forced changes.
+- id: 65-auth-13-pass-min-days
+  description: Ensure a minimum password age of 1 day to prevent rapid cycling through password history.
+  command: grep '^PASS_MIN_DAYS' /etc/login.defs | awk '{if($2>=1) print 1; else print 0}'
+  expected: 1
+  sudo: false
+  fix: sudo sed -i 's/^PASS_MIN_DAYS.*/PASS_MIN_DAYS 1/' /etc/login.defs
+  fix_sudo: true
+  affected_file: /etc/login.defs
+  post_action: None
+  security_level: baseline
+  risk_level: low
+  risk_desc: Low risk. Hinders users from immediately reverting to an old password.
+- id: 66-auth-14-account-inactivity
+  description: Ensure new accounts are disabled 30 days after password expiration (INACTIVE=30).
+  command: useradd -D | grep '^INACTIVE' | cut -d'=' -f2 | grep -q '30' && echo 1 || echo 0
+  expected: 1
+  sudo: false
+  fix: sudo useradd -D -f 30
+  fix_sudo: true
+  affected_file: /etc/default/useradd
+  post_action: None
+  security_level: high
+  risk_level: medium
+  risk_desc: Prevents abandoned accounts from remaining active and vulnerable to takeover.
+
+---
 title: User Authentication Hardening
 os: linux
 arch:
@@ -430,13 +965,16 @@ labels:
 - auth
 checksuites:
 - id: 40-auth-02-pass-complexity
-  description: Ensure password complexity is enforced (minlen=14).
+  description: Ensure password complexity enforces a minimum length of at least 14 characters (16 recommended).
   command: |
-    grep -E 'minlen\s*=\s*14' /etc/security/pwquality.conf | wc -l
+    v=$(grep -rhE '^[[:space:]]*minlen[[:space:]]*=' \
+          /etc/security/pwquality.conf /etc/security/pwquality.conf.d/ 2>/dev/null \
+        | tail -n1 | tr -dc '0-9')
+    [ -n "$v" ] || { echo 0; exit 0; }
+    [ "$v" -ge 14 ] && echo 1 || echo 0
   expected: 1
   sudo: true
-  fix: |
-    echo 'minlen=14' | sudo tee -a /etc/security/pwquality.conf
+  fix: sudo sed -i '/^[[:space:]]*minlen/d' /etc/security/pwquality.conf && echo 'minlen = 16' | sudo tee -a /etc/security/pwquality.conf
   fix_sudo: true
   affected_file: /etc/security/pwquality.conf
   post_action: None
@@ -446,7 +984,7 @@ checksuites:
 - id: 43-auth-05-root-lock
   description: Ensure the root account is locked to prevent direct login.
   command: |
-    sudo passwd -S root | grep -c 'L'
+    passwd -S root 2>/dev/null | awk '$2 ~ /^L/ {print}' | wc -l
   expected: 1
   sudo: true
   fix: sudo passwd -l root
@@ -456,6 +994,679 @@ checksuites:
   security_level: baseline
   risk_level: medium
   risk_desc: Requires a valid user with sudo privileges to be configured first.
+
+---
+title: Account Lockout (Faillock)
+os: linux
+arch:
+- amd64
+- arm64
+labels:
+- auth
+checksuites:
+- id: faillock-unlock-time
+  description: Verify that the account lockout duration is at least 180 seconds.
+  command: |
+    f=/etc/pam.d/system-auth
+    [ -f "$f" ] || f=/etc/pam.d/common-auth
+    [ -f "$f" ] || { echo 0; exit 0; }
+    grep -cE 'pam_faillock\.so.*unlock_time=(18[0-9]|19[0-9]|[2-9][0-9][0-9])' "$f" || true
+  expected: 2
+  expected_op: '>='
+  sudo: true
+  distro:
+    rocky:
+      command: grep -E 'pam_faillock.so.*unlock_time=(18[0-9]|19[0-9]|[2-9][0-9][0-9])' /etc/pam.d/system-auth | wc -l
+      fix: 'Manual action required: Ensure ''unlock_time=180'' is set for both pam_faillock entries in /etc/pam.d/system-auth.
+        On RHEL/Rocky/Fedora, prefer managing faillock settings via ''authselect'' or /etc/security/faillock.conf.'
+    rhel:
+      command: grep -E 'pam_faillock.so.*unlock_time=(18[0-9]|19[0-9]|[2-9][0-9][0-9])' /etc/pam.d/system-auth | wc -l
+      fix: 'Manual action required: Ensure ''unlock_time=180'' is set for both pam_faillock entries in /etc/pam.d/system-auth.
+        On RHEL/Rocky/Fedora, prefer managing faillock settings via ''authselect'' or /etc/security/faillock.conf.'
+    fedora:
+      command: grep -E 'pam_faillock.so.*unlock_time=(18[0-9]|19[0-9]|[2-9][0-9][0-9])' /etc/pam.d/system-auth | wc -l
+      fix: 'Manual action required: Ensure ''unlock_time=180'' is set for both pam_faillock entries in /etc/pam.d/system-auth.
+        On RHEL/Rocky/Fedora, prefer managing faillock settings via ''authselect'' or /etc/security/faillock.conf.'
+    archlinux:
+      command: grep -E 'pam_faillock.so.*unlock_time=(18[0-9]|19[0-9]|[2-9][0-9][0-9])' /etc/pam.d/system-auth | wc -l
+      fix: 'Manual action required: Ensure ''unlock_time=180'' is set for both pam_faillock entries in /etc/pam.d/system-auth.'
+  fix: 'Manual action required: Ensure ''unlock_time=180'' is set for both pam_faillock entries in /etc/pam.d/common-auth.'
+  fix_sudo: false
+  affected_file: /etc/pam.d/common-auth
+  post_action: None
+  security_level: baseline
+  risk_level: medium
+  risk_desc: A shorter unlock time increases the effectiveness of automated brute-force attacks.
+
+---
+
+title: Enforce Restrictive Default Umask
+os: linux
+arch:
+- amd64
+- arm64
+labels:
+- filesystem
+checksuites:
+- id: 81-fs-10-umask-login-defs
+  description: Verify that the default system-wide umask in /etc/login.defs is set to 027 or stricter.
+  command: |
+    grep -hE '^[[:space:]]*UMASK[[:space:]]+0?(27|77)[[:space:]]*$' /etc/login.defs 2>/dev/null | wc -l
+  expected: 1
+  expected_op: '>='
+  sudo: false
+  fix: sudo sed -i 's/^[[:space:]]*UMASK.*/UMASK 027/' /etc/login.defs
+  fix_sudo: true
+  affected_file: /etc/login.defs
+  post_action: Takes effect on the next login. Verify that pam_umask.so is present in the session stack (common-session on
+    Debian/Ubuntu/openSUSE, system-auth and password-auth on the RHEL family), otherwise this value only affects useradd.
+  security_level: baseline
+  risk_level: low
+  risk_desc: Affects newly created accounts and new sessions; does not retroactively change existing user files.
+- id: 82-fs-11-umask-shell-profile
+  description: Verify that a restrictive umask (027 or stricter) is set for Bourne-style login shells, as a backstop for systems
+    whose PAM session stack does not include pam_umask.so.
+  command: |
+    files="/etc/profile"
+    for f in /etc/profile.d/*.sh; do
+      [ -f "$f" ] && files="$files $f"
+    done
+    grep -hE '^[[:space:]]*umask[[:space:]]+0?(27|77)[[:space:]]*$' $files 2>/dev/null | wc -l
+  expected: 1
+  expected_op: '>='
+  sudo: false
+  fix: 'Manual action required: Create /etc/profile.d/50-umask.sh applying ''umask 027'' to accounts at or above UID_MIN and
+    ''umask 022'' below it (see the guide for the conditional block; use `id -u`, not $UID, so it also works under dash).
+    Do not edit /etc/profile directly. It is a package-managed file and direct edits are lost or cause conffile conflicts
+    on upgrade.'
+  fix_sudo: true
+  affected_file: /etc/profile.d/50-umask.sh
+  post_action: Settings take effect upon next login.
+  security_level: baseline
+  risk_level: medium
+  risk_desc: Global umask changes can lead to permission issues in shared environments or scripts. Applying the strict mask
+    below UID_MIN can break services that expect group-readable state files.
+
+---
+title: Securing the Path Environment Variable
+os: linux
+arch:
+- amd64
+- arm64
+labels:
+- auth
+checksuites:
+- id: 80-fs-09-path-writable
+  description: Verify that standard system PATH directories are not globally writable by non-privileged users.
+  command: find /usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin -type d -perm /0002 2>/dev/null | wc -l
+  expected: 0
+  sudo: false
+  fix: 'Manual action required: Identify the writable directory and remove the world-writable bit using `sudo chmod o-w <path>`.'
+  fix_sudo: true
+  affected_file: System PATH directories
+  post_action: None
+  security_level: high
+  risk_level: medium
+  risk_desc: Modifying permissions on critical system directories can lead to system instability.
+
+---
+title: Audit and Restrict SUID/SGID Executables
+os: linux
+arch:
+- amd64
+- arm64
+labels:
+- filesystem
+checksuites:
+- id: suid-sgid-file-count
+  description: Audit the number of files with the SUID or SGID permission bits set. This count must be monitored to detect
+    unauthorized changes.
+  command: sudo find / -xdev -type f -perm /06000 2>/dev/null | wc -l
+  expected: 150
+  expected_op: <=
+  sudo: true
+  fix: 'Manual action required: Review the list generated by the audit command, identify unnecessary binaries, and remove
+    the bits using ''sudo chmod u-s,g-s <file>''. WARNING: Do NOT remove SUID from essential binaries like /usr/bin/passwd
+    or /usr/bin/sudo.'
+  fix_sudo: true
+  affected_file: System executables
+  post_action: Perform functional testing of critical services (sudo, passwd, mount) to ensure required SUID binaries are
+    intact.
+  security_level: high
+  risk_level: high
+  risk_desc: Removing the SUID/SGID bit from essential system executables (e.g., 'sudo', 'mount', 'passwd') will immediately
+    break core system functionality and may lead to a loss of administrative control.
+- id: find-binary-not-suid
+  description: Verify that the 'find' utility binary itself does not have the SUID bit set, preventing potential misuse during
+    filesystem traversal.
+  command: |
+    fp=$(command -v find 2>/dev/null || echo /usr/bin/find)
+    [ -e "$fp" ] || { echo 0; exit 0; }
+    find "$fp" -perm -4000 2>/dev/null | wc -l
+  expected: 0
+  sudo: false
+  fix: |
+    fp=$(command -v find 2>/dev/null || echo /usr/bin/find)
+    sudo chmod u-s "$fp"
+  fix_sudo: true
+  affected_file: /usr/bin/find
+  post_action: None
+  security_level: baseline
+  risk_level: low
+  risk_desc: Removing the SUID bit from the 'find' utility is a standard security measure and should not affect its normal
+    function.
+
+---
+title: World Writable File and Directory Audit
+os: linux
+arch:
+- amd64
+- arm64
+labels:
+- filesystem
+checksuites:
+- id: 83-fs-12-audit-world-writable-files
+  description: Audit regular files with the world-writable bit set to prevent unauthorized modification.
+  command: sudo find / -xdev -type f -perm -0002 2>/dev/null | wc -l
+  expected: 0
+  sudo: true
+  fix: 'Manual action required: Remove the world-writable bit using `sudo chmod o-w <file>` after verifying the file purpose.'
+  fix_sudo: true
+  affected_file: System files
+  post_action: None.
+  security_level: high
+  risk_level: low
+  risk_desc: Standard files should never be world-writable; remediation secures system integrity.
+- id: 84-fs-13-audit-world-writable-directories
+  description: Audit directories (excluding temporary paths) that are writable by the world.
+  command: sudo find / -xdev -type d -perm -0002 -not -path '/tmp' -not -path '/var/tmp' -not -path '/dev/shm' 2>/dev/null
+    | wc -l
+  expected: 0
+  sudo: true
+  fix: 'Manual action required: Remove the world-writable bit using `sudo chmod o-w <directory>`.'
+  fix_sudo: true
+  affected_file: System directories
+  post_action: None.
+  security_level: high
+  risk_level: low
+  risk_desc: Misconfigured directories can allow attackers to plant malicious scripts.
+
+---
+title: Audit and Remediate Unowned and Ungrouped Files
+os: linux
+arch:
+- amd64
+- arm64
+labels:
+- filesystem
+checksuites:
+- id: audit-files-no-user
+  description: Audit all files on local filesystems that are owned by a numeric UID not defined in /etc/passwd (no valid user).
+  command: |
+    sub=/etc/subuid
+    [ -f "$sub" ] || sub=/dev/null
+    find / -xdev -nouser -printf '%%U\n' 2>/dev/null \
+    | awk -v subf="$sub" '
+        BEGIN { while ((getline line < subf) > 0) {
+                  split(line, f, ":")
+                  if (f[2] != "" && f[3] != "") { n++; lo[n]=f[2]+0; hi[n]=f[2]+f[3]-1 }
+                } }
+        { u=$1+0; ok=0
+          for (i=1; i<=n; i++) if (u >= lo[i] && u <= hi[i]) { ok=1; break }
+          if (!ok) c++ }
+        END { print c+0 }'
+  expected: 0
+  sudo: true
+  fix: 'Manual action required: Review the reported files individually. Do NOT blindly run ''chown root'' over them: files owned by an ID inside a /etc/subuid range belong to a rootless container and re-owning them destroys that container and its data (this check already excludes those). For genuinely orphaned files left by a deleted account, either delete them or reassign ownership to a valid account after confirming what they are.'
+  fix_sudo: true
+  affected_file: Filesystem metadata
+  post_action: None. This is a housekeeping task.
+  security_level: baseline
+  risk_level: low
+  risk_desc: Re-owning files is destructive and irreversible. Unowned files are usually the remains of a deleted account, but may also belong to a container runtime or a removable filesystem mounted from another host.
+- id: audit-files-no-group
+  description: Audit all files on local filesystems that are owned by a numeric GID not defined in /etc/group (no valid group).
+  command: |
+    sub=/etc/subgid
+    [ -f "$sub" ] || sub=/dev/null
+    find / -xdev -nogroup -printf '%%G\n' 2>/dev/null \
+    | awk -v subf="$sub" '
+        BEGIN { while ((getline line < subf) > 0) {
+                  split(line, f, ":")
+                  if (f[2] != "" && f[3] != "") { n++; lo[n]=f[2]+0; hi[n]=f[2]+f[3]-1 }
+                } }
+        { u=$1+0; ok=0
+          for (i=1; i<=n; i++) if (u >= lo[i] && u <= hi[i]) { ok=1; break }
+          if (!ok) c++ }
+        END { print c+0 }'
+  expected: 0
+  sudo: true
+  fix: 'Manual action required: Review the reported files individually. Do NOT blindly run ''chgrp root'' over them: files with a GID inside a /etc/subgid range belong to a rootless container and re-grouping them destroys that container and its data (this check already excludes those). For genuinely ungrouped files, either delete them or reassign the group after confirming what they are.'
+  fix_sudo: true
+  affected_file: Filesystem metadata
+  post_action: None. This is a housekeeping task.
+  security_level: baseline
+  risk_level: low
+  risk_desc: Re-grouping files is destructive and irreversible. Ungrouped files are usually the remains of a deleted group, but may also belong to a container runtime or a removable filesystem mounted from another host.
+
+---
+
+title: Kernel Hardening
+os: linux
+arch:
+- amd64
+- arm64
+labels:
+- kernel
+checksuites:
+- id: 14-kernel-01-dmesg-restrict
+  description: Restrict access to the kernel message buffer (dmesg) to root only to prevent information leakage.
+  command: |
+    cat /proc/sys/kernel/dmesg_restrict 2>/dev/null || echo 0
+  expected: 1
+  sudo: true
+  fix: |
+    sudo mkdir -p /etc/sysctl.d/
+    sudo touch /etc/sysctl.d/10-kernel-hardening.conf
+    echo 'kernel.dmesg_restrict=1' | sudo tee -a /etc/sysctl.d/10-kernel-hardening.conf
+  fix_sudo: true
+  affected_file: /etc/sysctl.d/10-kernel-hardening.conf
+  post_action: Run 'sudo sysctl -p /etc/sysctl.d/10-kernel-hardening.conf' to apply changes.
+  security_level: baseline
+  risk_level: low
+  risk_desc: Prevents non-root users from viewing kernel logs. May impact debugging tools running as user.
+- id: 15-kernel-02-randomize-va-space
+  description: Enable Address Space Layout Randomization (ASLR) to prevent buffer overflow exploits.
+  command: |
+    cat /proc/sys/kernel/randomize_va_space 2>/dev/null || echo 0
+  expected: 2
+  sudo: true
+  fix: |
+    sudo mkdir -p /etc/sysctl.d/
+    sudo touch /etc/sysctl.d/10-kernel-hardening.conf
+    echo 'kernel.randomize_va_space=2' | sudo tee -a /etc/sysctl.d/10-kernel-hardening.conf
+  fix_sudo: true
+  affected_file: /etc/sysctl.d/10-kernel-hardening.conf
+  post_action: Run 'sudo sysctl -p /etc/sysctl.d/10-kernel-hardening.conf' to apply changes.
+  security_level: baseline
+  risk_level: low
+  risk_desc: Standard security feature on modern Linux.
+- id: 16-kernel-03-disable-core-dumps
+  description: Restrict core dumps (fs.suid_dumpable) to prevent sensitive memory from being written to disk during crashes.
+  command: |
+    cat /proc/sys/fs/suid_dumpable 2>/dev/null || echo 1
+  expected: 0
+  sudo: true
+  fix: |
+    sudo mkdir -p /etc/sysctl.d/
+    sudo touch /etc/sysctl.d/10-kernel-hardening.conf
+    echo 'fs.suid_dumpable=0' | sudo tee -a /etc/sysctl.d/10-kernel-hardening.conf
+  fix_sudo: true
+  affected_file: /etc/sysctl.d/10-kernel-hardening.conf
+  post_action: Run 'sudo sysctl -p /etc/sysctl.d/10-kernel-hardening.conf' to apply changes.
+  security_level: high
+  risk_level: medium
+  risk_desc: Inhibits debugging of crashing services. Developers may need this re-enabled temporarily.
+- id: 17-kernel-04-yama-ptrace-scope
+  description: Restrict ptrace to prevent unprivileged processes from inspecting sibling processes.
+  requires_file: /proc/sys/kernel/yama/ptrace_scope
+  command: |
+    cat /proc/sys/kernel/yama/ptrace_scope 2>/dev/null || echo 0
+  expected: 1
+  expected_op: '>='
+  sudo: false
+  fix: |
+    sudo mkdir -p /etc/sysctl.d/
+    sudo touch /etc/sysctl.d/10-kernel-hardening.conf
+    echo 'kernel.yama.ptrace_scope=1' | sudo tee /etc/sysctl.d/10-kernel-hardening.conf
+  fix_sudo: true
+  affected_file: /etc/sysctl.d/10-kernel-hardening.conf
+  post_action: Run 'sudo sysctl -p /etc/sysctl.d/10-kernel-hardening.conf'.
+  security_level: baseline
+  risk_level: medium
+  risk_desc: May interfere with gdb/strace for non-root users.
+- id: 18-kernel-05-kptr-restrict
+  description: Hide kernel symbols/addresses from unprivileged users to mitigate KASLR bypass attacks.
+  command: |
+    cat /proc/sys/kernel/kptr_restrict 2>/dev/null || echo 0
+  expected: 2
+  sudo: true
+  fix: |
+    sudo mkdir -p /etc/sysctl.d/
+    sudo touch /etc/sysctl.d/10-kernel-hardening.conf
+    echo 'kernel.kptr_restrict=2' | sudo tee -a /etc/sysctl.d/10-kernel-hardening.conf
+  fix_sudo: true
+  affected_file: /etc/sysctl.d/10-kernel-hardening.conf
+  post_action: Run 'sudo sysctl -p /etc/sysctl.d/10-kernel-hardening.conf'.
+  security_level: high
+  risk_level: low
+  risk_desc: Essential for protecting against kernel exploits; minimal impact on normal operations.
+- id: 19-kernel-06-ebpf-unprivileged-disabled
+  description: Disable unprivileged eBPF to reduce the kernel attack surface.
+  command: |
+    cat /proc/sys/kernel/unprivileged_bpf_disabled 2>/dev/null || echo 0
+  expected: 1
+  sudo: true
+  fix: |
+    sudo mkdir -p /etc/sysctl.d/
+    sudo touch /etc/sysctl.d/10-kernel-hardening.conf
+    echo 'kernel.unprivileged_bpf_disabled=1' | sudo tee -a /etc/sysctl.d/10-kernel-hardening.conf
+  fix_sudo: true
+  affected_file: /etc/sysctl.d/10-kernel-hardening.conf
+  post_action: Run 'sudo sysctl -p /etc/sysctl.d/10-kernel-hardening.conf'.
+  security_level: high
+  risk_level: medium
+  risk_desc: Breaks non-root performance tracing and specific network filters.
+- id: 20-kernel-07-ebpf-jit-hardening
+  description: Enable eBPF JIT hardening to mitigate JIT spraying and information leaks.
+  command: |
+    cat /proc/sys/net/core/bpf_jit_harden 2>/dev/null || echo 0
+  expected: 2
+  sudo: true
+  fix: |
+    sudo mkdir -p /etc/sysctl.d/
+    sudo touch /etc/sysctl.d/10-kernel-hardening.conf
+    echo 'net.core.bpf_jit_harden=2' | sudo tee -a /etc/sysctl.d/10-kernel-hardening.conf
+  fix_sudo: true
+  affected_file: /etc/sysctl.d/10-kernel-hardening.conf
+  post_action: Run 'sudo sysctl -p /etc/sysctl.d/10-kernel-hardening.conf'.
+  security_level: high
+  risk_level: medium
+  risk_desc: Setting bpf_jit_harden=2 disables eBPF JIT for all programs; on client systems this can significantly degrade performance of browser-based seccomp filters.
+- id: 22-kernel-09-protected-fifos
+  description: Enable strict FIFO protection to prevent race conditions in named pipes.
+  command: |
+    cat /proc/sys/fs/protected_fifos 2>/dev/null || echo 0
+  expected: 2
+  sudo: true
+  fix: |
+    sudo mkdir -p /etc/sysctl.d/
+    sudo touch /etc/sysctl.d/10-kernel-hardening.conf
+    echo 'fs.protected_fifos=2' | sudo tee -a /etc/sysctl.d/10-kernel-hardening.conf
+  fix_sudo: true
+  affected_file: /etc/sysctl.d/10-kernel-hardening.conf
+  post_action: Run 'sudo sysctl -p /etc/sysctl.d/10-kernel-hardening.conf'.
+  security_level: high
+  risk_level: low
+  risk_desc: Prevents a common class of local privilege escalation.
+- id: 23-mod-01-blacklist-dccp
+  description: Blacklist the DCCP protocol module to reduce the network attack surface.
+  command: |
+    grep -rhE '^[[:space:]]*(blacklist[[:space:]]+dccp|install[[:space:]]+dccp[[:space:]]+/bin/(true|false))[[:space:]]*$' \
+      /etc/modprobe.d/ /run/modprobe.d/ /usr/lib/modprobe.d/ 2>/dev/null | wc -l
+  expected: 1
+  expected_op: '>='
+  sudo: true
+  fix: |
+    sudo mkdir -p /etc/modprobe.d/
+    sudo touch /etc/modprobe.d/blacklist-dccp.conf
+    echo 'blacklist dccp' | sudo tee /etc/modprobe.d/blacklist-dccp.conf
+  fix_sudo: true
+  affected_file: /etc/modprobe.d/blacklist-dccp.conf
+  post_action: Run 'sudo modprobe -r dccp' and update initramfs.
+  security_level: baseline
+  risk_level: low
+  risk_desc: Only impacts applications using the Datagram Congestion Control Protocol.
+- id: 24-mod-02-blacklist-sctp
+  description: Blacklist the SCTP protocol module to reduce the network attack surface.
+  command: |
+    grep -rhE '^[[:space:]]*(blacklist[[:space:]]+sctp|install[[:space:]]+sctp[[:space:]]+/bin/(true|false))[[:space:]]*$' \
+      /etc/modprobe.d/ /run/modprobe.d/ /usr/lib/modprobe.d/ 2>/dev/null | wc -l
+  expected: 1
+  expected_op: '>='
+  sudo: true
+  fix: |
+    sudo mkdir -p /etc/modprobe.d/
+    sudo touch /etc/modprobe.d/blacklist-sctp.conf
+    echo 'blacklist sctp' | sudo tee /etc/modprobe.d/blacklist-sctp.conf
+  fix_sudo: true
+  affected_file: /etc/modprobe.d/blacklist-sctp.conf
+  post_action: Run 'sudo modprobe -r sctp' and update initramfs.
+  security_level: baseline
+  risk_level: low
+  risk_desc: Disables Stream Control Transmission Protocol.
+- id: 25-net-01-syn-cookies
+  description: Enable TCP SYN cookies to mitigate SYN flood Denial of Service (DoS) attacks.
+  command: |
+    cat /proc/sys/net/ipv4/tcp_syncookies 2>/dev/null || echo 0
+  expected: 1
+  sudo: true
+  fix: |
+    sudo mkdir -p /etc/sysctl.d/
+    sudo touch /etc/sysctl.d/90-network-hardening.conf
+    echo 'net.ipv4.tcp_syncookies=1' | sudo tee -a /etc/sysctl.d/90-network-hardening.conf
+  fix_sudo: true
+  affected_file: /etc/sysctl.d/90-network-hardening.conf
+  post_action: Run 'sudo sysctl -p /etc/sysctl.d/90-network-hardening.conf' to apply changes.
+  security_level: baseline
+  risk_level: low
+  risk_desc: Activates only under high load/attack. No impact on normal traffic.
+- id: 26-net-02-rp-filter
+  description: Enable Reverse Path Filtering (Anti-spoofing) to validate source addresses. Any non-zero value (1=strict, 2=loose)
+    is acceptable, as some distros default to 2.
+  command: |
+    cat /proc/sys/net/ipv4/conf/all/rp_filter 2>/dev/null || echo 0
+  expected: 1
+  expected_op: '>='
+  sudo: false
+  fix: echo 'net.ipv4.conf.all.rp_filter=1' | sudo tee -a /etc/sysctl.d/90-network-hardening.conf
+  fix_sudo: true
+  affected_file: /etc/sysctl.d/90-network-hardening.conf
+  post_action: Run 'sudo sysctl -p /etc/sysctl.d/90-network-hardening.conf' to apply changes.
+  security_level: baseline
+  risk_level: medium
+  risk_desc: Strict mode (1) may drop packets in asymmetric routing environments. Use loose mode (2) if connectivity fails.
+- id: 27-net-03-accept-redirects
+  description: Disable acceptance of ICMP redirects to prevent routing table manipulation (MITM).
+  command: |
+    cat /proc/sys/net/ipv4/conf/all/accept_redirects 2>/dev/null || echo 1
+  expected: 0
+  sudo: true
+  fix: echo 'net.ipv4.conf.all.accept_redirects=0' | sudo tee -a /etc/sysctl.d/90-network-hardening.conf
+  fix_sudo: true
+  affected_file: /etc/sysctl.d/90-network-hardening.conf
+  post_action: Run 'sudo sysctl -p /etc/sysctl.d/90-network-hardening.conf' to apply changes.
+  security_level: high
+  risk_level: low
+  risk_desc: Safe to disable unless the network relies on dynamic legacy routing updates.
+- id: 28-net-04-source-route
+  description: Disable acceptance of packets with source routing options.
+  command: |
+    cat /proc/sys/net/ipv4/conf/all/accept_source_route 2>/dev/null || echo 1
+  expected: 0
+  sudo: true
+  fix: echo 'net.ipv4.conf.all.accept_source_route=0' | sudo tee -a /etc/sysctl.d/90-network-hardening.conf
+  fix_sudo: true
+  affected_file: /etc/sysctl.d/90-network-hardening.conf
+  post_action: Run 'sudo sysctl -p /etc/sysctl.d/90-network-hardening.conf' to apply changes.
+  security_level: baseline
+  risk_level: low
+  risk_desc: Source routing is deprecated and rarely used; disabling has no operational risk.
+- id: 29-net-05-bogus-icmp
+  description: Ignore ICMP packets with bogus error responses to reduce log noise and potential DoS.
+  command: |
+    cat /proc/sys/net/ipv4/icmp_ignore_bogus_error_responses 2>/dev/null || echo 0
+  expected: 1
+  sudo: true
+  fix: echo 'net.ipv4.icmp_ignore_bogus_error_responses=1' | sudo tee -a /etc/sysctl.d/90-network-hardening.conf
+  fix_sudo: true
+  affected_file: /etc/sysctl.d/90-network-hardening.conf
+  post_action: Run 'sudo sysctl -p /etc/sysctl.d/90-network-hardening.conf' to apply changes.
+  security_level: baseline
+  risk_level: low
+  risk_desc: Pure security measure; no impact on legitimate traffic.
+- id: 30-net-06-ipv4-ip_forward-disabled
+  description: Ensure IP forwarding is disabled.
+  command: |
+    cat /proc/sys/net/ipv4/ip_forward 2>/dev/null || echo 1
+  expected: 0
+  sudo: false
+  fix: |
+    sysctl -w net.ipv4.ip_forward=0
+    sed -i "/net.ipv4.ip_forward/d" /etc/sysctl.conf
+    echo "net.ipv4.ip_forward = 0" >> /etc/sysctl.conf
+  fix_sudo: true
+  affected_file: /etc/sysctl.conf
+  post_action: None
+  security_level: baseline
+  risk_level: medium
+  risk_desc: Prevents routing packets between network interfaces.
+- id: 31-net-07-ipv4-conf-all-send_redirects-disabled
+  description: Disable ICMP send_redirects.
+  command: |
+    cat /proc/sys/net/ipv4/conf/all/send_redirects 2>/dev/null || echo 1
+  expected: 0
+  sudo: false
+  fix: |
+    sysctl -w net.ipv4.conf.all.send_redirects=0
+    sed -i "/net.ipv4.conf.all.send_redirects/d" /etc/sysctl.conf
+    echo "net.ipv4.conf.all.send_redirects = 0" >> /etc/sysctl.conf
+  fix_sudo: true
+  affected_file: /etc/sysctl.conf
+  post_action: None
+  security_level: baseline
+  risk_level: low
+  risk_desc: Safe security change for standard operations.
+---
+title: IPv6 Attack Surface Reduction
+os: linux
+arch:
+- amd64
+- arm64
+labels:
+- network
+- kernel
+checksuites:
+- id: ipv6-accept-redirects-disabled
+  description: Disable acceptance of ICMPv6 redirects to prevent Man-in-the-Middle routing manipulation.
+  command: |
+    [ -d /proc/sys/net/ipv6 ] || { echo 0; exit 0; }
+    cat /proc/sys/net/ipv6/conf/all/accept_redirects 2>/dev/null || echo 0
+  expected: 0
+  sudo: true
+  fix: |
+    sudo tee -a /etc/sysctl.d/90-ipv6-harden.conf <<EOF
+    net.ipv6.conf.all.accept_redirects = 0
+    net.ipv6.conf.default.accept_redirects = 0
+    EOF
+  fix_sudo: true
+  affected_file: /etc/sysctl.d/90-ipv6-harden.conf
+  post_action: Run 'sudo sysctl -p /etc/sysctl.d/90-ipv6-harden.conf' to apply.
+  security_level: high
+  risk_level: low
+  risk_desc: Prevents unauthorized route injection via ICMPv6.
+- id: ipv6-source-route-disabled
+  description: Disable acceptance of IPv6 packets with source routing options.
+  command: |
+    [ -d /proc/sys/net/ipv6 ] || { echo 0; exit 0; }
+    cat /proc/sys/net/ipv6/conf/all/accept_source_route 2>/dev/null || echo 0
+  expected: 0
+  sudo: true
+  fix: |
+    sudo tee -a /etc/sysctl.d/90-ipv6-harden.conf <<EOF
+    net.ipv6.conf.all.accept_source_route = 0
+    net.ipv6.conf.default.accept_source_route = 0
+    EOF
+  fix_sudo: true
+  affected_file: /etc/sysctl.d/90-ipv6-harden.conf
+  post_action: Run 'sudo sysctl -p /etc/sysctl.d/90-ipv6-harden.conf'.
+  security_level: baseline
+  risk_level: low
+  risk_desc: Source routing is deprecated and poses a security risk; disabling it has no operational impact.
+- id: ipv6-privacy-extensions
+  description: Verify that IPv6 Privacy Extensions (RFC 4941) are enabled.
+  command: |
+    [ -d /proc/sys/net/ipv6 ] || { echo 2; exit 0; }
+    cat /proc/sys/net/ipv6/conf/all/use_tempaddr 2>/dev/null || echo 2
+  expected: 2
+  sudo: true
+  fix: |
+    sudo tee -a /etc/sysctl.d/90-ipv6-harden.conf <<EOF
+    net.ipv6.conf.all.use_tempaddr = 2
+    net.ipv6.conf.default.use_tempaddr = 2
+    EOF
+  fix_sudo: true
+  affected_file: /etc/sysctl.d/90-ipv6-harden.conf
+  post_action: Run 'sudo sysctl -p /etc/sysctl.d/90-ipv6-harden.conf'.
+  security_level: baseline
+  risk_level: low
+  risk_desc: Essential for protecting client identity by preventing hardware-based EUI-64 tracking.
+- id: ipv6-router-advertisements-restricted
+  description: Ensure the system ignores Hop Limit and other configuration flags in Router Advertisements.
+  command: |
+    [ -d /proc/sys/net/ipv6 ] || { echo 1; exit 0; }
+    cat /proc/sys/net/ipv6/conf/all/accept_ra_pinfo 2>/dev/null || echo 1
+  expected: 1
+  sudo: true
+  fix: |
+    sudo tee -a /etc/sysctl.d/90-ipv6-harden.conf <<EOF
+    net.ipv6.conf.all.accept_ra_pinfo = 1
+    net.ipv6.conf.all.accept_ra_defrtr = 1
+    EOF
+  fix_sudo: true
+  affected_file: /etc/sysctl.d/90-ipv6-harden.conf
+  post_action: Run 'sudo sysctl -p /etc/sysctl.d/90-ipv6-harden.conf'.
+  security_level: high
+  risk_level: low
+  risk_desc: Hardens the processing of RAs while maintaining basic connectivity.
+
+---
+title: Ensure Correct Loopback and Local Host Configuration
+os: linux
+arch:
+- amd64
+- arm64
+labels:
+- network
+checksuites:
+- id: 67-hosts-loopback-ipv4
+  description: Verify that the IPv4 loopback address (127.0.0.1) is correctly configured for localhost.
+  command: |
+    grep -E '^\s*127\.0\.0\.1[[:space:]]+([^#[:space:]]+[[:space:]]+)*localhost([[:space:]]|$)' /etc/hosts | wc -l
+  expected: 1
+  expected_op: '>='
+  sudo: false
+  fix: 'Manual action required: Ensure the line ''127.0.0.1 localhost'' is present in /etc/hosts. Incorrect configuration
+    may break local inter-process communication.'
+  fix_sudo: true
+  affected_file: /etc/hosts
+  post_action: None
+  security_level: baseline
+  risk_level: low
+  risk_desc: Essential for local services to resolve correctly.
+- id: 68-hosts-loopback-ipv6
+  description: Verify that the IPv6 loopback address (::1) is correctly configured for localhost.
+  command: |
+    grep -E '^\s*::1[[:space:]]+([^#[:space:]]+[[:space:]]+)*(localhost|ip6-localhost)([[:space:]]|$)' /etc/hosts | wc -l
+  expected: 1
+  expected_op: '>='
+  sudo: false
+  fix: 'Manual action required: Ensure the line ''::1 localhost'' is present in /etc/hosts.'
+  fix_sudo: true
+  affected_file: /etc/hosts
+  post_action: None
+  security_level: baseline
+  risk_level: low
+  risk_desc: Prevents resolution delays or failures in IPv6-enabled applications.
+- id: 69-hosts-hostname-resolution
+  description: Verify that the system hostname is correctly mapped in the hosts file.
+  command: |
+    HN=$( (command -v hostname >/dev/null 2>&1 && hostname) \
+          || (command -v hostnamectl >/dev/null 2>&1 && hostnamectl --static 2>/dev/null) \
+          || (cat /etc/hostname 2>/dev/null) )
+    HN=$(printf '%s' "$HN" | tr -d '[:space:]')
+    [ -n "$HN" ] || { echo 0; exit 0; }
+    grep -cE "^\s*(127\.0\.(0|1)\.1)\s+${HN}([[:space:]]|$)" /etc/hosts
+  expected: 1
+  expected_op: '>='
+  sudo: false
+  fix: 'Manual action required: Add a line mapping 127.0.1.1 to your hostname (check via ''hostname'' command).'
+  fix_sudo: true
+  affected_file: /etc/hosts
+  post_action: None
+  security_level: baseline
+  risk_level: low
+  risk_desc: Ensures system tools can resolve the local hostname without external DNS.
 
 ---
 
@@ -484,8 +1695,6 @@ checksuites:
   risk_desc: Removes packages that transmit data in clear text.
 - id: svc-disable-avahi
   description: Ensure the Avahi daemon is disabled/masked or not installed at all.
-  # Passes unless the unit is actively "enabled". "not-found", "disabled",
-  # "masked", "static", "indirect", empty, etc. all count as "not enabled".
   command: |
     state=$(systemctl is-enabled avahi-daemon.service 2>/dev/null | tr -d '[:space:]' || true)
     if [ "$state" = "enabled" ] || [ "$state" = "alias" ]; then echo 0; else echo 1; fi
@@ -501,8 +1710,11 @@ checksuites:
 - id: cups-localhost-only
   description: Verify that the CUPS printing service is restricted to the localhost interface.
   command: |
-    grep -rE '^\s*Listen\s+(localhost:631|127\.0\.0\.1:631|/run/cups/cups\.sock)' /etc/cups/cupsd.conf | wc -l
+    [ -f /etc/cups/cupsd.conf ] || { echo 1; exit 0; }
+    grep -rhE '^[[:space:]]*Listen[[:space:]]+(localhost:631|127\.0\.0\.1:631|/run/cups/cups\.sock)' \
+      /etc/cups/cupsd.conf 2>/dev/null | wc -l
   expected: 1
+  expected_op: '>='
   sudo: true
   fix: 'Manual action required: Edit /etc/cups/cupsd.conf to ensure ''Listen'' directives only point to localhost or the local
     socket.'
@@ -515,7 +1727,6 @@ checksuites:
 - id: svc-disable-bluetooth
   description: Ensure Bluetooth services are disabled/masked or not installed on systems where wireless communication is not
     required.
-  # Same pattern as svc-disable-avahi — pass unless the unit is enabled.
   command: |
     state=$(systemctl is-enabled bluetooth.service 2>/dev/null | tr -d '[:space:]' || true)
     if [ "$state" = "enabled" ] || [ "$state" = "alias" ]; then echo 0; else echo 1; fi
@@ -530,7 +1741,165 @@ checksuites:
   risk_desc: Reduces the wireless attack surface.
 
 ---
+title: SSH Client Security
+os: linux
+arch:
+- amd64
+- arm64
+labels:
+- network
+checksuites:
+- id: ssh-server-removed
+  description: Ensure the SSH server daemon is not installed to close the remote access attack surface.
+  command: command -v sshd >/dev/null 2>&1 && echo 1 || echo 0
+  expected: 0
+  sudo: false
+  fix: 'Manual action required: Remove the SSH server package. Debian/Ubuntu: sudo apt-get purge -y openssh-server |
+    RHEL/Rocky/Fedora: sudo dnf remove -y openssh-server | SUSE: sudo zypper remove -y openssh-server | Arch: sudo
+    pacman -R openssh (Arch ships client and server in a single package; removing it drops both, so use
+    ''systemctl disable --now sshd'' instead if you only want the daemon inactive).'
+  fix_sudo: false
+  affected_file: N/A
+  post_action: None
+  security_level: high
+  risk_level: low
+  risk_desc: Closing the SSH port prevents remote unauthorized login attempts.
+- id: ssh-client-installed
+  description: Verify that the SSH client is installed for secure outgoing connections.
+  command: command -v ssh >/dev/null 2>&1 && echo 1 || echo 0
+  expected: 1
+  sudo: false
+  fix: 'Manual action required: Install the SSH client package. Debian/Ubuntu: sudo apt-get install -y openssh-client |
+    RHEL/Rocky/Fedora: sudo dnf install -y openssh-clients | SUSE: sudo zypper install -y openssh-clients | Arch:
+    sudo pacman -S --noconfirm openssh (single package provides both client and server on Arch).'
+  fix_sudo: false
+  affected_file: N/A
+  post_action: None
+  security_level: baseline
+  risk_level: low
+  risk_desc: Required for the user to securely connect to other remote systems.
 
+---
+title: CUPS Security Hardening
+os: linux
+arch:
+- amd64
+- arm64
+labels:
+- services
+checksuites:
+- id: cups-browsed-disabled
+  description: The cups-browsed service must be disabled or masked to prevent automatic printer discovery and reduce the attack surface.
+  command: |
+    out=$(systemctl is-enabled cups-browsed 2>/dev/null)
+    printf '%s\n' "$out" | grep -cx enabled || true
+  expected: 0
+  sudo: false
+  fix: sudo systemctl disable --now cups-browsed
+  fix_sudo: true
+  affected_file: /etc/systemd/system/cups-browsed.service
+  post_action: None
+  security_level: baseline
+  risk_level: low
+  risk_desc: Disabling this service will prevent the automatic discovery and listing of remote network printers. Users will
+    need to add printers manually if required.
+
+---
+title: Disable or Remove Unnecessary File Sharing Services (Samba)
+os: linux
+arch:
+- amd64
+- arm64
+labels:
+- services
+checksuites:
+- id: samba-service-inactive-or-not-installed
+  description: The Samba service must be inactive and disabled, or not installed, to minimize the attack surface. Unit
+    names differ by distro, with smbd/nmbd on Debian/Ubuntu/RHEL-family/SUSE, but smb/nmb on Arch's samba package.
+  command: |
+    { systemctl is-enabled smbd 2>/dev/null; systemctl is-enabled nmbd 2>/dev/null; } \
+      | grep -cx enabled || true
+  expected: 0
+  sudo: false
+  distro:
+    arch:
+      command: (systemctl is-enabled smb 2>/dev/null; systemctl is-enabled nmb 2>/dev/null) | grep -c '^enabled'
+      fix: systemctl disable --now smb nmb 2>/dev/null || true
+  fix: systemctl disable --now smbd nmbd 2>/dev/null || true
+  fix_sudo: true
+  affected_file: N/A
+  post_action: 'Manual action required: If the service persists, remove the samba package. Debian/Ubuntu: sudo apt purge
+    samba | RHEL/Rocky/Fedora: sudo dnf remove -y samba | SUSE: sudo zypper remove samba | Arch: sudo pacman -R samba'
+  security_level: baseline
+  risk_level: low
+  risk_desc: Disabling or removing Samba will prevent SMB/CIFS file sharing. Only disruptive if the system is intended as
+    a Windows-compatible file server.
+
+---
+title: DNS Resolver Security
+os: linux
+arch:
+- amd64
+- arm64
+labels:
+- network
+checksuites:
+- id: 64-dns-loopback-bind
+  description: Verify that local DNS resolver services are restricted to the loopback address to prevent network exposure.
+  command: |
+    command -v ss >/dev/null 2>&1 || { echo 0; exit 0; }
+    ss -tuln 2>/dev/null \
+      | awk 'NR>1 { n=split($5,a,":"); if (a[n]==53) print $5 }' \
+      | grep -vcE '^(127\.[0-9]+\.[0-9]+\.[0-9]+|\[?::1\]?)' || true
+  expected: 0
+  sudo: true
+  fix: 'Manual action required: Edit the configuration of your resolver (systemd-resolved or Unbound) to ensure it only listens
+    on 127.0.0.1.'
+  fix_sudo: true
+  affected_file: Resolver configuration file
+  post_action: Restart the resolver service.
+  security_level: baseline
+  risk_level: medium
+  risk_desc: Incorrectly restricting addresses may break DNS for local virtual machines or containers.
+- id: 65-resolv-conf-perms
+  description: Ensure the effective /etc/resolv.conf is owned by root and not writable by group or other.
+  command: |
+    t=$(readlink -f /etc/resolv.conf 2>/dev/null)
+    [ -n "$t" ] && [ -e "$t" ] || { echo 0; exit 0; }
+    find "$t" -maxdepth 0 -user root ! -perm /go=w -print 2>/dev/null | wc -l
+  expected: 1
+  sudo: false
+  fix: |
+    t=$(readlink -f /etc/resolv.conf)
+    chown root:root "$t"
+    chmod go-w "$t"
+  fix_sudo: true
+  affected_file: /etc/resolv.conf (symlink target is chown'ed/chmod'ed, not the link itself)
+  post_action: 'If the resolved target is under /run (systemd-resolved, netconfig), it is regenerated on every boot and this
+    fix does NOT persist. On such systems the durable control is the integrity of /etc/systemd/resolved.conf(.d) or /etc/sysconfig/network/config,
+    which must be root-owned and not group- or world-writable. Do not use ''chattr +i'' on a resolver-managed /etc/resolv.conf,
+    because it breaks systemd-resolved and NetworkManager updates.'
+  security_level: baseline
+  risk_level: low
+  risk_desc: Standard permission hardening on an already root-owned file. Detects tampering rather than remediating a common
+    misconfiguration.
+- id: 66-dns-secure-transport
+  description: Verify that the resolver uses DNS-over-TLS (DoT) or DNSSEC validation.
+  command: |
+    grep -rhE '^[[:space:]]*(DNSOverTLS[[:space:]]*=[[:space:]]*(yes|opportunistic)|DNSSEC[[:space:]]*=[[:space:]]*(yes|allow-downgrade)|tls-port)' \
+      /etc/systemd/resolved.conf /etc/systemd/resolved.conf.d/ /etc/unbound/ 2>/dev/null | wc -l
+  expected: 1
+  expected_op: '>='
+  sudo: false
+  fix: 'Manual action required: Set DNSOverTLS=opportunistic in /etc/systemd/resolved.conf. Do NOT use DNSOverTLS=yes unless every configured resolver is known to support DNS-over-TLS: strict mode makes name resolution fail completely when it does not, which on a client looks like a total loss of network connectivity.'
+  fix_sudo: true
+  affected_file: Resolver configuration file
+  post_action: Restart the resolver service.
+  security_level: high
+  risk_level: medium
+  risk_desc: Opportunistic mode encrypts where the resolver supports it and falls back to plain DNS otherwise, so it cannot break resolution. Strict mode (DNSOverTLS=yes) can.
+
+---
 title: Configuring and Hardening the Host Firewall
 os: linux
 arch:
@@ -552,7 +1921,7 @@ checksuites:
     Manual action required: Enable and start your system's host firewall.
     On Ubuntu (UFW is preinstalled):
       sudo ufw enable
-    On Debian/Arch (no firewall frontend ships by default — install one first):
+    On Debian/Arch (no firewall frontend ships by default, install one first):
       sudo apt install ufw && sudo ufw enable          # Debian
       sudo pacman -S ufw && sudo systemctl enable --now ufw   # Arch
     On Rocky/AlmaLinux/Fedora/RHEL/SUSE (firewalld is preinstalled and usually already enabled):
@@ -597,353 +1966,6 @@ checksuites:
   risk_desc: Ensures no external connections are accepted unless explicitly allowed.
 
 ---
-
-title: SSH Client Security
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- network
-checksuites:
-- id: ssh-server-removed
-  description: Ensure the SSH server daemon is not installed to close the remote access attack surface.
-  command: command -v sshd >/dev/null 2>&1 && echo 1 || echo 0
-  expected: 0
-  sudo: false
-  fix: 'Manual action required: Remove the SSH server package. Debian/Ubuntu: sudo apt-get purge -y openssh-server |
-    RHEL/Rocky/Fedora: sudo dnf remove -y openssh-server | SUSE: sudo zypper remove -y openssh-server | Arch: sudo
-    pacman -R openssh (Arch ships client and server in a single package; removing it drops both, so use
-    ''systemctl disable --now sshd'' instead if you only want the daemon inactive).'
-  fix_sudo: false
-  affected_file: N/A
-  post_action: None
-  security_level: high
-  risk_level: low
-  risk_desc: Closing the SSH port prevents remote unauthorized login attempts.
-- id: ssh-client-installed
-  description: Verify that the SSH client is installed for secure outgoing connections.
-  command: command -v ssh >/dev/null 2>&1 && echo 1 || echo 0
-  expected: 1
-  sudo: false
-  fix: 'Manual action required: Install the SSH client package. Debian/Ubuntu: sudo apt-get install -y openssh-client |
-    RHEL/Rocky/Fedora: sudo dnf install -y openssh-clients | SUSE: sudo zypper install -y openssh-clients | Arch:
-    sudo pacman -S --noconfirm openssh (single package provides both client and server on Arch).'
-  fix_sudo: false
-  affected_file: N/A
-  post_action: None
-  security_level: baseline
-  risk_level: low
-  risk_desc: Required for the user to securely connect to other remote systems.
-
----
-
-title: Kernel Hardening
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- kernel
-checksuites:
-- id: 14-kernel-01-dmesg-restrict
-  description: Restrict access to the kernel message buffer (dmesg) to root only to prevent information leakage.
-  command: cat /proc/sys/kernel/dmesg_restrict
-  expected: 1
-  sudo: true
-  fix: |
-    sudo mkdir -p /etc/sysctl.d/
-    sudo touch /etc/sysctl.d/10-kernel-hardening.conf
-    echo 'kernel.dmesg_restrict=1' | sudo tee -a /etc/sysctl.d/10-kernel-hardening.conf
-  fix_sudo: true
-  affected_file: /etc/sysctl.d/10-kernel-hardening.conf
-  post_action: Run 'sudo sysctl -p /etc/sysctl.d/10-kernel-hardening.conf' to apply changes.
-  security_level: baseline
-  risk_level: low
-  risk_desc: Prevents non-root users from viewing kernel logs. May impact debugging tools running as user.
-- id: 15-kernel-02-randomize-va-space
-  description: Enable Address Space Layout Randomization (ASLR) to prevent buffer overflow exploits.
-  command: cat /proc/sys/kernel/randomize_va_space
-  expected: 2
-  sudo: true
-  fix: |
-    sudo mkdir -p /etc/sysctl.d/
-    sudo touch /etc/sysctl.d/10-kernel-hardening.conf
-    echo 'kernel.randomize_va_space=2' | sudo tee -a /etc/sysctl.d/10-kernel-hardening.conf
-  fix_sudo: true
-  affected_file: /etc/sysctl.d/10-kernel-hardening.conf
-  post_action: Run 'sudo sysctl -p /etc/sysctl.d/10-kernel-hardening.conf' to apply changes.
-  security_level: baseline
-  risk_level: low
-  risk_desc: Standard security feature on modern Linux.
-- id: 16-kernel-03-disable-core-dumps
-  description: Restrict core dumps (fs.suid_dumpable) to prevent sensitive memory from being written to disk during crashes.
-  command: cat /proc/sys/fs/suid_dumpable
-  expected: 0
-  sudo: true
-  fix: |
-    sudo mkdir -p /etc/sysctl.d/
-    sudo touch /etc/sysctl.d/10-kernel-hardening.conf
-    echo 'fs.suid_dumpable=0' | sudo tee -a /etc/sysctl.d/10-kernel-hardening.conf
-  fix_sudo: true
-  affected_file: /etc/sysctl.d/10-kernel-hardening.conf
-  post_action: Run 'sudo sysctl -p /etc/sysctl.d/10-kernel-hardening.conf' to apply changes.
-  security_level: high
-  risk_level: medium
-  risk_desc: Inhibits debugging of crashing services. Developers may need this re-enabled temporarily.
-- id: 17-kernel-04-yama-ptrace-scope
-  description: Restrict ptrace to prevent unprivileged processes from inspecting sibling processes.
-  # Requires the Yama LSM — not compiled into every kernel (e.g. openSUSE Leap
-  # 15.6 default). Skip with a neutral "missing" state where /proc/sys/kernel/yama
-  # is absent rather than falsely reporting a hardening failure.
-  requires_file: /proc/sys/kernel/yama/ptrace_scope
-  command: cat /proc/sys/kernel/yama/ptrace_scope
-  expected: 1
-  expected_op: '>='
-  sudo: false
-  fix: |
-    sudo mkdir -p /etc/sysctl.d/
-    sudo touch /etc/sysctl.d/10-kernel-hardening.conf
-    echo 'kernel.yama.ptrace_scope=1' | sudo tee /etc/sysctl.d/10-kernel-hardening.conf
-  fix_sudo: true
-  affected_file: /etc/sysctl.d/10-kernel-hardening.conf
-  post_action: Run 'sudo sysctl -p /etc/sysctl.d/10-kernel-hardening.conf'.
-  security_level: baseline
-  risk_level: medium
-  risk_desc: May interfere with gdb/strace for non-root users.
-- id: 18-kernel-05-kptr-restrict
-  description: Hide kernel symbols/addresses from unprivileged users to mitigate KASLR bypass attacks.
-  command: cat /proc/sys/kernel/kptr_restrict
-  expected: 2
-  sudo: true
-  fix: |
-    sudo mkdir -p /etc/sysctl.d/
-    sudo touch /etc/sysctl.d/10-kernel-hardening.conf
-    echo 'kernel.kptr_restrict=2' | sudo tee -a /etc/sysctl.d/10-kernel-hardening.conf
-  fix_sudo: true
-  affected_file: /etc/sysctl.d/10-kernel-hardening.conf
-  post_action: Run 'sudo sysctl -p /etc/sysctl.d/10-kernel-hardening.conf'.
-  security_level: high
-  risk_level: low
-  risk_desc: Essential for protecting against kernel exploits; minimal impact on normal operations.
-- id: 19-kernel-06-ebpf-unprivileged-disabled
-  description: Disable unprivileged eBPF to reduce the kernel attack surface.
-  command: cat /proc/sys/kernel/unprivileged_bpf_disabled
-  expected: 1
-  sudo: true
-  fix: |
-    sudo mkdir -p /etc/sysctl.d/
-    sudo touch /etc/sysctl.d/10-kernel-hardening.conf
-    echo 'kernel.unprivileged_bpf_disabled=1' | sudo tee -a /etc/sysctl.d/10-kernel-hardening.conf
-  fix_sudo: true
-  affected_file: /etc/sysctl.d/10-kernel-hardening.conf
-  post_action: Run 'sudo sysctl -p /etc/sysctl.d/10-kernel-hardening.conf'.
-  security_level: high
-  risk_level: medium
-  risk_desc: Breaks non-root performance tracing and specific network filters.
-- id: 20-kernel-07-ebpf-jit-hardening
-  description: Enable eBPF JIT hardening to mitigate JIT spraying and information leaks.
-  command: cat /proc/sys/net/core/bpf_jit_harden
-  expected: 2
-  sudo: true
-  fix: |
-    sudo mkdir -p /etc/sysctl.d/
-    sudo touch /etc/sysctl.d/10-kernel-hardening.conf
-    echo 'net.core.bpf_jit_harden=2' | sudo tee -a /etc/sysctl.d/10-kernel-hardening.conf
-  fix_sudo: true
-  affected_file: /etc/sysctl.d/10-kernel-hardening.conf
-  post_action: Run 'sudo sysctl -p /etc/sysctl.d/10-kernel-hardening.conf'.
-  security_level: high
-  risk_level: medium
-  risk_desc: Setting bpf_jit_harden=2 disables eBPF JIT for all programs; on client systems this can significantly degrade performance of browser-based seccomp filters.
-- id: 21-kernel-08-userns-clone-disabled
-  description: Disable unprivileged user namespace creation to limit attack surface.
-  command: cat /proc/sys/kernel/unprivileged_userns_clone
-  expected: 0
-  sudo: true
-  fix: |
-    sudo mkdir -p /etc/sysctl.d/
-    sudo touch /etc/sysctl.d/10-kernel-hardening.conf
-    echo 'kernel.unprivileged_userns_clone=0' | sudo tee -a /etc/sysctl.d/10-kernel-hardening.conf
-  fix_sudo: true
-  affected_file: /etc/sysctl.d/10-kernel-hardening.conf
-  post_action: Run 'sudo sysctl -p /etc/sysctl.d/10-kernel-hardening.conf'.
-  security_level: high
-  risk_level: high
-  risk_desc: 'CRITICAL: Breaks rootless containers (Podman), Flatpaks, and browser sandboxing.'
-- id: 22-kernel-09-protected-fifos
-  description: Enable strict FIFO protection to prevent race conditions in named pipes.
-  command: cat /proc/sys/fs/protected_fifos
-  expected: 2
-  sudo: true
-  fix: |
-    sudo mkdir -p /etc/sysctl.d/
-    sudo touch /etc/sysctl.d/10-kernel-hardening.conf
-    echo 'fs.protected_fifos=2' | sudo tee -a /etc/sysctl.d/10-kernel-hardening.conf
-  fix_sudo: true
-  affected_file: /etc/sysctl.d/10-kernel-hardening.conf
-  post_action: Run 'sudo sysctl -p /etc/sysctl.d/10-kernel-hardening.conf'.
-  security_level: high
-  risk_level: low
-  risk_desc: Prevents a common class of local privilege escalation.
-- id: 23-mod-01-blacklist-dccp
-  description: Blacklist the DCCP protocol module to reduce the network attack surface.
-  command: |
-    grep -r 'blacklist dccp' /etc/modprobe.d/ | wc -l
-  expected: 1
-  sudo: false
-  fix: |
-    sudo mkdir -p /etc/modprobe.d/
-    sudo touch /etc/modprobe.d/blacklist-dccp.conf
-    echo 'blacklist dccp' | sudo tee /etc/modprobe.d/blacklist-dccp.conf
-  fix_sudo: true
-  affected_file: /etc/modprobe.d/blacklist-dccp.conf
-  post_action: Run 'sudo modprobe -r dccp' and update initramfs.
-  security_level: baseline
-  risk_level: low
-  risk_desc: Only impacts applications using the Datagram Congestion Control Protocol.
-- id: 24-mod-02-blacklist-sctp
-  description: Blacklist the SCTP protocol module to reduce the network attack surface.
-  command: |
-    grep -r 'blacklist sctp' /etc/modprobe.d/ | wc -l
-  expected: 1
-  sudo: false
-  fix: |
-    sudo mkdir -p /etc/modprobe.d/
-    sudo touch /etc/modprobe.d/blacklist-sctp.conf
-    echo 'blacklist sctp' | sudo tee /etc/modprobe.d/blacklist-sctp.conf
-  fix_sudo: true
-  affected_file: /etc/modprobe.d/blacklist-sctp.conf
-  post_action: Run 'sudo modprobe -r sctp' and update initramfs.
-  security_level: baseline
-  risk_level: low
-  risk_desc: Disables Stream Control Transmission Protocol.
-- id: 25-net-01-syn-cookies
-  description: Enable TCP SYN cookies to mitigate SYN flood Denial of Service (DoS) attacks.
-  command: cat /proc/sys/net/ipv4/tcp_syncookies
-  expected: 1
-  sudo: true
-  fix: |
-    sudo mkdir -p /etc/sysctl.d/
-    sudo touch /etc/sysctl.d/90-network-hardening.conf
-    echo 'net.ipv4.tcp_syncookies=1' | sudo tee -a /etc/sysctl.d/90-network-hardening.conf
-  fix_sudo: true
-  affected_file: /etc/sysctl.d/90-network-hardening.conf
-  post_action: Run 'sudo sysctl -p /etc/sysctl.d/90-network-hardening.conf' to apply changes.
-  security_level: baseline
-  risk_level: low
-  risk_desc: Activates only under high load/attack. No impact on normal traffic.
-- id: 26-net-02-rp-filter
-  description: Enable Reverse Path Filtering (Anti-spoofing) to validate source addresses. Any non-zero value (1=strict, 2=loose)
-    is acceptable — some distros default to 2.
-  command: cat /proc/sys/net/ipv4/conf/all/rp_filter
-  expected: 1
-  expected_op: '>='
-  sudo: false
-  fix: echo 'net.ipv4.conf.all.rp_filter=1' | sudo tee -a /etc/sysctl.d/90-network-hardening.conf
-  fix_sudo: true
-  affected_file: /etc/sysctl.d/90-network-hardening.conf
-  post_action: Run 'sudo sysctl -p /etc/sysctl.d/90-network-hardening.conf' to apply changes.
-  security_level: baseline
-  risk_level: medium
-  risk_desc: Strict mode (1) may drop packets in asymmetric routing environments. Use loose mode (2) if connectivity fails.
-- id: 27-net-03-accept-redirects
-  description: Disable acceptance of ICMP redirects to prevent routing table manipulation (MITM).
-  command: cat /proc/sys/net/ipv4/conf/all/accept_redirects
-  expected: 0
-  sudo: true
-  fix: echo 'net.ipv4.conf.all.accept_redirects=0' | sudo tee -a /etc/sysctl.d/90-network-hardening.conf
-  fix_sudo: true
-  affected_file: /etc/sysctl.d/90-network-hardening.conf
-  post_action: Run 'sudo sysctl -p /etc/sysctl.d/90-network-hardening.conf' to apply changes.
-  security_level: high
-  risk_level: low
-  risk_desc: Safe to disable unless the network relies on dynamic legacy routing updates.
-- id: 28-net-04-source-route
-  description: Disable acceptance of packets with source routing options.
-  command: cat /proc/sys/net/ipv4/conf/all/accept_source_route
-  expected: 0
-  sudo: true
-  fix: echo 'net.ipv4.conf.all.accept_source_route=0' | sudo tee -a /etc/sysctl.d/90-network-hardening.conf
-  fix_sudo: true
-  affected_file: /etc/sysctl.d/90-network-hardening.conf
-  post_action: Run 'sudo sysctl -p /etc/sysctl.d/90-network-hardening.conf' to apply changes.
-  security_level: baseline
-  risk_level: low
-  risk_desc: Source routing is deprecated and rarely used; disabling has no operational risk.
-- id: 29-net-05-bogus-icmp
-  description: Ignore ICMP packets with bogus error responses to reduce log noise and potential DoS.
-  command: cat /proc/sys/net/ipv4/icmp_ignore_bogus_error_responses
-  expected: 1
-  sudo: true
-  fix: echo 'net.ipv4.icmp_ignore_bogus_error_responses=1' | sudo tee -a /etc/sysctl.d/90-network-hardening.conf
-  fix_sudo: true
-  affected_file: /etc/sysctl.d/90-network-hardening.conf
-  post_action: Run 'sudo sysctl -p /etc/sysctl.d/90-network-hardening.conf' to apply changes.
-  security_level: baseline
-  risk_level: low
-  risk_desc: Pure security measure; no impact on legitimate traffic.
-- id: 30-net-06-ipv4-ip_forward-disabled
-  description: Ensure IP forwarding is disabled.
-  command: cat /proc/sys/net/ipv4/ip_forward
-  expected: 0
-  sudo: false
-  fix: |
-    sysctl -w net.ipv4.ip_forward=0
-    sed -i "/net.ipv4.ip_forward/d" /etc/sysctl.conf
-    echo "net.ipv4.ip_forward = 0" >> /etc/sysctl.conf
-  fix_sudo: true
-  affected_file: /etc/sysctl.conf
-  post_action: None
-  security_level: baseline
-  risk_level: medium
-  risk_desc: Prevents routing packets between network interfaces.
-- id: 31-net-07-ipv4-conf-all-send_redirects-disabled
-  description: Disable ICMP send_redirects.
-  command: cat /proc/sys/net/ipv4/conf/all/send_redirects
-  expected: 0
-  sudo: false
-  fix: |
-    sysctl -w net.ipv4.conf.all.send_redirects=0
-    sed -i "/net.ipv4.conf.all.send_redirects/d" /etc/sysctl.conf
-    echo "net.ipv4.conf.all.send_redirects = 0" >> /etc/sysctl.conf
-  fix_sudo: true
-  affected_file: /etc/sysctl.conf
-  post_action: None
-  security_level: baseline
-  risk_level: low
-  risk_desc: Safe security change for standard operations.
-- id: 32-mod-01-disable-usb-storage
-  description: Prevent the 'usb-storage' kernel module from loading.
-  command: |
-    grep -r 'install usb-storage /bin/true' /etc/modprobe.d/ | wc -l
-  expected: 1
-  sudo: false
-  fix: |
-    echo 'install usb-storage /bin/true' | sudo tee /etc/modprobe.d/blacklist-usb-storage.conf
-  fix_sudo: true
-  affected_file: /etc/modprobe.d/blacklist-usb-storage.conf
-  post_action: Reboot required to unload active modules.
-  security_level: high
-  risk_level: medium
-  risk_desc: Disables ALL USB mass storage devices.
-- id: 33-crypto-01-fips-mode
-  description: Ensure the OS implements NIST FIPS-validated cryptography (Auditing only).
-  command: cat /proc/sys/crypto/fips_enabled
-  expected: 1
-  sudo: false
-  fix: 'Manual action required: Enabling FIPS requires installing certified packages (e.g., ubuntu-fips) and modifying the
-    bootloader. Automated fixing is unsafe.'
-  fix_sudo: false
-  affected_file: /boot/grub/grub.cfg
-  post_action: N/A
-  security_level: high
-  risk_level: high
-  risk_desc: Enabling FIPS often disables non-compliant crypto (e.g., certain SSH ciphers), potentially locking out remote
-    access.
-
----
-
 title: Configure TCP Wrappers and Hosts Access
 os: linux
 arch:
@@ -956,10 +1978,13 @@ checksuites:
   description: 'Enforce a ''Default Deny'' policy by ensuring /etc/hosts.deny contains ''ALL: ALL''. This ensures that only
     services explicitly listed in /etc/hosts.allow are accessible. /etc/hosts.deny ships out of the box on Debian/Ubuntu
     (netbase) and is present on RHEL/Rocky/Fedora/SUSE, but Arch ships neither the file nor a packaged tcp_wrappers
-    (only available via the AUR) — the check is skipped there instead of failing on a file that was never meant to exist.'
+    (only available via the AUR), so the check is skipped there instead of failing on a file that was never meant to exist.'
   requires_file: /etc/hosts.deny
-  command: grep -Px "ALL:\s*ALL" /etc/hosts.deny | wc -l
+  command: |
+    grep -hE '^[[:space:]]*ALL[[:space:]]*:[[:space:]]*ALL[[:space:]]*$' \
+      /etc/hosts.deny 2>/dev/null | wc -l
   expected: 1
+  expected_op: '>='
   sudo: true
   fix: |
     Manual action required: Add a default-deny rule to /etc/hosts.deny.
@@ -970,7 +1995,7 @@ checksuites:
     Note: On Rocky/Fedora/RHEL, verify the tcp_wrappers package is installed:
       e.g., sudo dnf install tcp-wrappers   (RHEL/Rocky/Fedora)
             sudo zypper install tcpd         (SUSE)
-    On Arch, tcp_wrappers is only available via the AUR (e.g. yay -S tcp_wrappers) and is unmaintained upstream —
+    On Arch, tcp_wrappers is only available via the AUR (e.g. yay -S tcp_wrappers) and is unmaintained upstream -
     prefer nftables/firewalld/ufw rules over reviving it.
   fix_sudo: true
   affected_file: /etc/hosts.deny
@@ -983,7 +2008,8 @@ checksuites:
   description: Ensure restrictive permissions (0644) are set on /etc/hosts.allow to prevent unauthorized modification of access
     control rules. Skipped on distros (e.g. Arch) that ship without this file.
   requires_file: /etc/hosts.allow
-  command: stat -c '%a' /etc/hosts.allow
+  command: |
+    stat -c '%a' /etc/hosts.allow 2>/dev/null || echo missing
   expected: 644
   sudo: false
   fix: sudo chmod 0644 /etc/hosts.allow
@@ -997,7 +2023,8 @@ checksuites:
   description: Ensure restrictive permissions (0644) are set on /etc/hosts.deny. Skipped on distros (e.g. Arch) that ship
     without this file.
   requires_file: /etc/hosts.deny
-  command: stat -c '%a' /etc/hosts.deny
+  command: |
+    stat -c '%a' /etc/hosts.deny 2>/dev/null || echo missing
   expected: 644
   sudo: false
   fix: sudo chmod 0644 /etc/hosts.deny
@@ -1021,15 +2048,12 @@ checksuites:
 - id: chronyd-active
   description: Verify that a time synchronization service (chrony or systemd-timesyncd) is actively running to ensure accurate
     timekeeping.
-  # Check each service in sequence — the pipe/OR pattern from the previous
-  # version dropped output from the fallback branch. Any one being active is
-  # enough (expected_op: '>=').
   command: |
     {
       systemctl is-active chronyd 2>/dev/null
       systemctl is-active chrony 2>/dev/null
       systemctl is-active systemd-timesyncd 2>/dev/null
-    } | grep -c '^active$'
+    } | grep -cx active || true
   expected: 1
   expected_op: '>='
   sudo: false
@@ -1046,9 +2070,6 @@ checksuites:
 - id: chronyd-non-root
   description: Verify that the time-sync daemon (chrony or systemd-timesyncd) runs as an unprivileged user to minimize the impact
     of a potential compromise.
-  # Use /proc directly — `ps` isn't always installed on minimal images
-  # (openSUSE Leap 15.6 base). Match chronyd/chrony/systemd-timesyncd; report
-  # 1 (pass) if all matching processes run as non-root.
   command: |
     matched=0
     non_root=0
@@ -1078,9 +2099,6 @@ checksuites:
   risk_desc: This is usually the default setting in modern distributions and only confirms privilege separation.
 - id: chrony-cmd-restriction
   description: Ensure that Chrony's command interface (for control and monitoring) is restricted to the localhost interface.
-  # Detect the config file at runtime: /etc/chrony/chrony.conf on Debian/Ubuntu,
-  # /etc/chrony.conf on RHEL-family/openSUSE/Arch. Skip cleanly if chrony
-  # isn't installed (neither file present).
   command: |
     f=/etc/chrony/chrony.conf
     [ -f "$f" ] || f=/etc/chrony.conf
@@ -1103,7 +2121,9 @@ checksuites:
 - id: chrony-nts-config
   description: Verify that Network Time Security (NTS) is configured on at least one time source to cryptographically authenticate
     the time provided.
-  command: grep -c 'nts' /etc/chrony/chrony.conf
+  command: |
+    grep -rhE '^[[:space:]]*(server|pool)[[:space:]]+\S+.*[[:space:]]nts([[:space:]]|$)' \
+      /etc/chrony.conf /etc/chrony/chrony.conf /etc/chrony/conf.d/ /etc/chrony.d/ 2>/dev/null | wc -l
   expected: 1
   expected_op: '>='
   sudo: false
@@ -1126,1210 +2146,62 @@ checksuites:
     affecting system stability.
 
 ---
-
-title: IPv6 Attack Surface Reduction
+title: Systemd Journal Hardening and Integrity
 os: linux
 arch:
 - amd64
 - arm64
 labels:
-- network
-- kernel
+- logging
 checksuites:
-- id: ipv6-accept-redirects-disabled
-  description: Disable acceptance of ICMPv6 redirects to prevent Man-in-the-Middle routing manipulation.
-  command: cat /proc/sys/net/ipv6/conf/all/accept_redirects
-  expected: 0
-  sudo: true
-  fix: |
-    sudo tee -a /etc/sysctl.d/90-ipv6-harden.conf <<EOF
-    net.ipv6.conf.all.accept_redirects = 0
-    net.ipv6.conf.default.accept_redirects = 0
-    EOF
-  fix_sudo: true
-  affected_file: /etc/sysctl.d/90-ipv6-harden.conf
-  post_action: Run 'sudo sysctl -p /etc/sysctl.d/90-ipv6-harden.conf' to apply.
-  security_level: high
-  risk_level: low
-  risk_desc: Prevents unauthorized route injection via ICMPv6.
-- id: ipv6-source-route-disabled
-  description: Disable acceptance of IPv6 packets with source routing options.
-  command: cat /proc/sys/net/ipv6/conf/all/accept_source_route
-  expected: 0
-  sudo: true
-  fix: |
-    sudo tee -a /etc/sysctl.d/90-ipv6-harden.conf <<EOF
-    net.ipv6.conf.all.accept_source_route = 0
-    net.ipv6.conf.default.accept_source_route = 0
-    EOF
-  fix_sudo: true
-  affected_file: /etc/sysctl.d/90-ipv6-harden.conf
-  post_action: Run 'sudo sysctl -p /etc/sysctl.d/90-ipv6-harden.conf'.
-  security_level: baseline
-  risk_level: low
-  risk_desc: Source routing is deprecated and poses a security risk; disabling it has no operational impact.
-- id: ipv6-privacy-extensions
-  description: Verify that IPv6 Privacy Extensions (RFC 4941) are enabled.
-  command: cat /proc/sys/net/ipv6/conf/all/use_tempaddr
-  expected: 2
-  sudo: true
-  fix: |
-    sudo tee -a /etc/sysctl.d/90-ipv6-harden.conf <<EOF
-    net.ipv6.conf.all.use_tempaddr = 2
-    net.ipv6.conf.default.use_tempaddr = 2
-    EOF
-  fix_sudo: true
-  affected_file: /etc/sysctl.d/90-ipv6-harden.conf
-  post_action: Run 'sudo sysctl -p /etc/sysctl.d/90-ipv6-harden.conf'.
-  security_level: baseline
-  risk_level: low
-  risk_desc: Essential for protecting client identity by preventing hardware-based EUI-64 tracking.
-- id: ipv6-router-advertisements-restricted
-  description: Ensure the system ignores Hop Limit and other configuration flags in Router Advertisements.
-  command: cat /proc/sys/net/ipv6/conf/all/accept_ra_pinfo
-  expected: 1
-  sudo: true
-  fix: |
-    sudo tee -a /etc/sysctl.d/90-ipv6-harden.conf <<EOF
-    net.ipv6.conf.all.accept_ra_pinfo = 1
-    net.ipv6.conf.all.accept_ra_defrtr = 1
-    EOF
-  fix_sudo: true
-  affected_file: /etc/sysctl.d/90-ipv6-harden.conf
-  post_action: Run 'sudo sysctl -p /etc/sysctl.d/90-ipv6-harden.conf'.
-  security_level: high
-  risk_level: low
-  risk_desc: Hardens the processing of RAs while maintaining basic connectivity.
-
----
-
-title: CUPS Security Hardening
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- services
-checksuites:
-- id: cups-browsed-disabled
-  description: The cups-browsed service must be disabled or masked to prevent automatic printer discovery and reduce the attack surface.
-  command: systemctl is-enabled cups-browsed 2>/dev/null | grep -cE '^enabled$'
-  expected: 0
-  sudo: false
-  fix: sudo systemctl disable --now cups-browsed
-  fix_sudo: true
-  affected_file: /etc/systemd/system/cups-browsed.service
-  post_action: None
-  security_level: baseline
-  risk_level: low
-  risk_desc: Disabling this service will prevent the automatic discovery and listing of remote network printers. Users will
-    need to add printers manually if required.
-
----
-
-title: Disable or Remove Unnecessary File Sharing Services (Samba)
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- services
-checksuites:
-- id: samba-service-inactive-or-not-installed
-  description: The Samba service must be inactive and disabled, or not installed, to minimize the attack surface. Unit
-    names differ by distro — smbd/nmbd on Debian/Ubuntu/RHEL-family/SUSE, but smb/nmb on Arch's samba package.
-  command: (systemctl is-enabled smbd 2>/dev/null; systemctl is-enabled nmbd 2>/dev/null) | grep -c '^enabled'
-  expected: 0
-  sudo: false
-  distro:
-    arch:
-      command: (systemctl is-enabled smb 2>/dev/null; systemctl is-enabled nmb 2>/dev/null) | grep -c '^enabled'
-      fix: systemctl disable --now smb nmb 2>/dev/null || true
-  fix: systemctl disable --now smbd nmbd 2>/dev/null || true
-  fix_sudo: true
-  affected_file: N/A
-  post_action: 'Manual action required: If the service persists, remove the samba package. Debian/Ubuntu: sudo apt purge
-    samba | RHEL/Rocky/Fedora: sudo dnf remove -y samba | SUSE: sudo zypper remove samba | Arch: sudo pacman -R samba'
-  security_level: baseline
-  risk_level: low
-  risk_desc: Disabling or removing Samba will prevent SMB/CIFS file sharing. Only disruptive if the system is intended as
-    a Windows-compatible file server.
-
----
-
-title: DNS Resolver Security
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- network
-checksuites:
-- id: 64-dns-loopback-bind
-  description: Verify that local DNS resolver services are restricted to the loopback address to prevent network exposure.
-  # Whole 127.0.0.0/8 is loopback — systemd-resolved binds to 127.0.0.53/54
-  # on Ubuntu/Debian, which the previous regex incorrectly flagged as
-  # non-loopback.
+- id: journald-persistent-storage
+  description: Verify that journal storage is set to 'persistent' to retain forensic logs across reboots.
   command: |
-    sudo ss -tuln | awk '$5 ~ /:53$/' | grep -vE '(127\.[0-9]+\.[0-9]+\.[0-9]+|::1|\[::1\])' | wc -l
-  expected: 0
-  sudo: true
-  fix: 'Manual action required: Edit the configuration of your resolver (systemd-resolved or Unbound) to ensure it only listens
-    on 127.0.0.1.'
+    grep -hE '^[[:space:]]*Storage[[:space:]]*=[[:space:]]*persistent' \
+      /etc/systemd/journald.conf /etc/systemd/journald.conf.d/*.conf 2>/dev/null | wc -l
+  expected: '1'
+  expected_op: '>='
+  sudo: false
+  fix: |
+    sudo sed -i 's/^#\?Storage=.*/Storage=persistent/' /etc/systemd/journald.conf
   fix_sudo: true
-  affected_file: Resolver configuration file
-  post_action: Restart the resolver service.
+  affected_file: /etc/systemd/journald.conf
+  post_action: 'Restart journald: sudo systemctl restart systemd-journald'
   security_level: baseline
-  risk_level: medium
-  risk_desc: Incorrectly restricting addresses may break DNS for local virtual machines or containers.
-- id: 65-resolv-conf-perms
-  description: Ensure restrictive permissions (0644) are set on /etc/resolv.conf.
-  command: stat -c '%a' /etc/resolv.conf
-  expected: 644
+  risk_level: low
+  risk_desc: Changing storage creates the /var/log/journal directory, which is necessary for forensic integrity.
+- id: journald-compression-enabled
+  description: Verify that log compression is not explicitly disabled (default is enabled).
+  command: |
+    grep -hE '^[[:space:]]*Compress[[:space:]]*=[[:space:]]*no' \
+      /etc/systemd/journald.conf /etc/systemd/journald.conf.d/*.conf 2>/dev/null | wc -l
+  expected: '0'
+  sudo: false
+  fix: |
+    sudo sed -i 's/^#\\?Compress=.*/Compress=yes/' /etc/systemd/journald.conf
+  fix_sudo: true
+  affected_file: /etc/systemd/journald.conf
+  post_action: 'Restart journald: sudo systemctl restart systemd-journald'
+  security_level: baseline
+  risk_level: low
+  risk_desc: Compression saves disk space and does not affect log integrity.
+- id: journald-persistent-dir-perms
+  description: Verify that the persistent journal directory (/var/log/journal) has restrictive permissions (e.g., 2755) and
+    the SetGID bit set.
+  command: |
+    stat -c '%a' /var/log/journal 2>/dev/null || echo missing
+  expected: 2755
   expected_op: <=
   sudo: false
-  fix: sudo chmod 0644 /etc/resolv.conf
+  fix: sudo chmod 2755 /var/log/journal
   fix_sudo: true
-  affected_file: /etc/resolv.conf
-  post_action: None
-  security_level: baseline
-  risk_level: low
-  risk_desc: Standard permission hardening.
-- id: 66-dns-secure-transport
-  description: Verify that the resolver uses DNS-over-TLS (DoT) or DNSSEC validation.
-  command: |
-    grep -rhE '^\s*(DNSOverTLS|DNSSEC|tls-port)\s*=\s*(yes|on|[1-9])' /etc/systemd/resolved.conf /etc/unbound/ 2>/dev/null | wc -l
-  expected: 1
-  expected_op: '>='
-  sudo: false
-  fix: 'Manual action required: Configure systemd-resolved to use DNSOverTLS=yes in /etc/systemd/resolved.conf.'
-  fix_sudo: true
-  affected_file: Resolver configuration file
-  post_action: Restart the resolver service.
-  security_level: high
-  risk_level: high
-  risk_desc: Incorrect settings will break all internet name resolution.
-
----
-
-title: Ensure Correct Loopback and Local Host Configuration
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- network
-checksuites:
-- id: 67-hosts-loopback-ipv4
-  description: Verify that the IPv4 loopback address (127.0.0.1) is correctly configured for localhost.
-  # Regex tolerates Arch's default "127.0.0.1 localhost.localdomain localhost"
-  # by allowing intermediate aliases before the "localhost" token.
-  command: |
-    grep -E '^\s*127\.0\.0\.1[[:space:]]+([^#[:space:]]+[[:space:]]+)*localhost([[:space:]]|$)' /etc/hosts | wc -l
-  expected: 1
-  expected_op: '>='
-  sudo: false
-  fix: 'Manual action required: Ensure the line ''127.0.0.1 localhost'' is present in /etc/hosts. Incorrect configuration
-    may break local inter-process communication.'
-  fix_sudo: true
-  affected_file: /etc/hosts
-  post_action: None
-  security_level: baseline
-  risk_level: low
-  risk_desc: Essential for local services to resolve correctly.
-- id: 68-hosts-loopback-ipv6
-  description: Verify that the IPv6 loopback address (::1) is correctly configured for localhost.
-  # Accept either "localhost" or the Debian/Ubuntu default "ip6-localhost"
-  # and tolerate multiple aliases on the line.
-  command: |
-    grep -E '^\s*::1[[:space:]]+([^#[:space:]]+[[:space:]]+)*(localhost|ip6-localhost)([[:space:]]|$)' /etc/hosts | wc -l
-  expected: 1
-  expected_op: '>='
-  sudo: false
-  fix: 'Manual action required: Ensure the line ''::1 localhost'' is present in /etc/hosts.'
-  fix_sudo: true
-  affected_file: /etc/hosts
-  post_action: None
-  security_level: baseline
-  risk_level: low
-  risk_desc: Prevents resolution delays or failures in IPv6-enabled applications.
-- id: 69-hosts-hostname-resolution
-  description: Verify that the system hostname is correctly mapped in the hosts file.
-  # Fall back to `hostnamectl --static` then /etc/hostname because the plain
-  # `hostname` binary isn't always installed on Arch/openSUSE minimal images.
-  command: |
-    HN=$( (command -v hostname >/dev/null 2>&1 && hostname) \
-          || (command -v hostnamectl >/dev/null 2>&1 && hostnamectl --static 2>/dev/null) \
-          || (cat /etc/hostname 2>/dev/null) )
-    HN=$(printf '%s' "$HN" | tr -d '[:space:]')
-    [ -n "$HN" ] || { echo 0; exit 0; }
-    grep -cE "^\s*(127\.0\.(0|1)\.1)\s+${HN}([[:space:]]|$)" /etc/hosts
-  expected: 1
-  expected_op: '>='
-  sudo: false
-  fix: 'Manual action required: Add a line mapping 127.0.1.1 to your hostname (check via ''hostname'' command).'
-  fix_sudo: true
-  affected_file: /etc/hosts
-  post_action: None
-  security_level: baseline
-  risk_level: low
-  risk_desc: Ensures system tools can resolve the local hostname without external DNS.
-
----
-
-title: Secure BIOS/UEFI Settings
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- boot
-checksuites:
-- id: bios-password-set
-  description: Verify that a BIOS/UEFI administrator password is set to prevent unauthorized firmware changes.
-  command: Manual verification required.
-  expected: Password is set
-  sudo: false
-  fix: 'Manual action required: Enter the BIOS/UEFI setup utility and set an Administrator Password.'
-  fix_sudo: false
-  affected_file: Firmware
-  post_action: None
-  security_level: high
-  risk_level: low
-  risk_desc: Non-disruptive but critical for preventing firmware-level bypasses.
-- id: secure-boot-enabled
-  description: Ensure Secure Boot is enabled to maintain the cryptographic chain of trust.
-  command: sudo dmesg | grep -i "secure boot"
-  expected: Secure boot enabled
-  sudo: true
-  fix: 'Manual action required: Enter the BIOS/UEFI setup utility and enable Secure Boot.'
-  fix_sudo: false
-  affected_file: Firmware
-  post_action: None
-  security_level: high
-  risk_level: medium
-  risk_desc: May prevent booting if using unsigned custom kernels or drivers.
-- id: boot-order-restricted
-  description: Verify the boot order is restricted to the local disk to prevent external media booting.
-  command: Manual verification required.
-  expected: Local disk only
-  sudo: false
-  fix: 'Manual action required: Set the boot order to local hard disk only and disable USB/Network boot.'
-  fix_sudo: false
-  affected_file: Firmware
-  post_action: None
-  security_level: high
-  risk_level: low
-  risk_desc: Prevents unauthorized OS loading from USB; must be temporarily reverted for recovery.
-
----
-
-title: Secure GRUB Bootloader with a Password
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- boot
-checksuites:
-- id: 37-fs-04-bootloader-password
-  description: Verify the bootloader requires a password for single-user mode. Only applies to GRUB; skipped on systems
-    booting via systemd-boot or rEFInd (common on Arch, and increasingly offered as an option elsewhere), which have no
-    grub.cfg and use a different (currently unaudited) mechanism for boot entry protection.
-  requires_file: /boot/grub/grub.cfg
-  command: |
-    grep -i '^password_pbkdf2' /boot/grub/grub.cfg | wc -l
-  expected: 1
-  sudo: true
-  fix: |
-    Manual action required: Run 'grub-mkpasswd-pbkdf2' and configure /etc/grub.d/00_header.
-  fix_sudo: false
-  affected_file: /boot/grub/grub.cfg
-  post_action: None
-  security_level: high
-  risk_level: high
-  risk_desc: Misconfiguration can render the system unbootable or lock out administrators.
-
----
-
-title: Kernel Command Line Hardening
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- kernel
-- boot
-checksuites:
-- id: cmdline-mem-protection
-  description: Verify that security-critical kernel parameters (slab_nomerge, vsyscall, pti) are active in the boot configuration.
-  command: cat /proc/cmdline | grep -E 'slab_nomerge|vsyscall=none|pti=on' | wc -l
-  expected: 3
-  sudo: false
-  fix: 'Manual action required: Edit GRUB_CMDLINE_LINUX_DEFAULT in /etc/default/grub to include these parameters and run update-grub.'
-  fix_sudo: true
-  affected_file: /etc/default/grub
-  post_action: Reboot required to apply kernel parameters.
-  security_level: high
-  risk_level: low
-  risk_desc: Improves memory protection with minimal performance impact.
-- id: initramfs-shell-disabled
-  description: Verify that the initramfs debug shell is disabled to prevent unauthorized console access.
-  command: cat /proc/cmdline | grep -E 'panic=0|rd.shell=0' | wc -l
-  expected: 1
-  sudo: false
-  fix: 'Manual action required: Add ''panic=0'' (Debian/Ubuntu) or ''rd.shell=0'' (RHEL/Fedora) to the kernel command line.'
-  fix_sudo: true
-  affected_file: /etc/default/grub
-  post_action: Reboot required.
-  security_level: high
-  risk_level: medium
-  risk_desc: Prevents a bypass to a root shell, but requires live media for troubleshooting boot failures.
-
----
-
-title: UEFI Secure Boot Verification
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- boot
-checksuites:
-- id: secure-boot-active
-  description: Verify that UEFI Secure Boot is enabled and active, ensuring only signed code is executed during the boot process.
-    mokutil ships by default on Ubuntu/Fedora/RHEL-family but is an optional install on Debian, SUSE, and Arch. Only
-    meaningful on UEFI systems; BIOS/legacy-boot VMs are skipped cleanly.
-  requires_command: mokutil
-  requires_file: /sys/firmware/efi
-  command: mokutil --sb-state | grep -cE 'SecureBoot\s+(is\s+)?enabled'
-  expected: 1
-  sudo: false
-  distro:
-    debian:
-      command: |
-        if ! command -v mokutil >/dev/null 2>&1; then echo 1; else mokutil --sb-state | grep -cE 'SecureBoot\s+(is\s+)?enabled'; fi
-  fix: 'Manual action required: Access the system''s UEFI/BIOS firmware settings and change ''Secure Boot'' from Disabled
-    to Enabled. NOTE: Ensure all boot components are signed beforehand.'
-  fix_sudo: true
-  affected_file: System Firmware/UEFI
-  post_action: None
-  security_level: baseline
-  risk_level: high
-  risk_desc: Enabling Secure Boot without using signed kernel modules or bootloaders (e.g., custom or self-compiled kernels)
-    will result in the system being unable to boot.
-- id: secure-boot-user-mode
-  description: Verify that the system is operating in User Mode (not Setup Mode) to ensure that the cryptographic keys are
-    installed and enforcing the signing policy. Only meaningful on UEFI systems; BIOS/legacy-boot VMs are skipped
-    cleanly rather than reported as failures.
-  # /sys/firmware/efi only exists when booted in UEFI mode. bootctl is available
-  # everywhere systemd is installed but has nothing to report on BIOS.
-  requires_command: bootctl
-  requires_file: /sys/firmware/efi
-  command: 'bootctl status | grep -c ''Setup Mode: no'''
-  expected: 1
-  sudo: false
-  distro:
-    debian:
-      command: |
-        if ! command -v bootctl >/dev/null 2>&1; then echo 1; else bootctl status 2>/dev/null | grep -c 'Setup Mode: no'; fi
-  fix: 'Manual action required: If in Setup Mode, the administrator must install the platform keys (PK, KEK, DB) via the firmware
-    interface or using tools like efitools and transition the system to User Mode.'
-  fix_sudo: true
-  affected_file: System Firmware/UEFI
-  post_action: None
-  security_level: baseline
-  risk_level: low
-  risk_desc: Setup Mode means keys are manageable but not enforced; verifying User Mode is a safety check.
-- id: kernel-sig-enforce
-  description: Verify that the kernel is enforcing module signature checks at runtime, which is required when Secure Boot
-    is active.
-  command: cat /proc/sys/kernel/module_sig_enforce
-  expected: 1
-  sudo: false
-  fix: 'Manual action required: If this value is 0 despite Secure Boot being enabled, the kernel may be custom-built without
-    signature enforcement. Recompile the kernel with the appropriate configuration options enabled.'
-  fix_sudo: true
-  affected_file: Kernel runtime status
-  post_action: None
-  security_level: high
-  risk_level: low
-  risk_desc: This check does not alter the system; it only verifies the security state.
-
----
-
-title: Verify Package Integrity
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- services
-checksuites:
-- id: aide-package-installed
-  description: Verify that the AIDE binary is present on the system for proactive file integrity monitoring.
-  command: command -v aide >/dev/null 2>&1 && echo 1 || echo 0
-  expected: 1
-  sudo: false
-  fix: 'Manual action required: Install AIDE. Debian/Ubuntu: sudo apt install aide aide-common | RHEL/Rocky/Fedora: sudo
-    dnf install -y aide | OpenSUSE: sudo zypper install -y aide | Arch: sudo pacman -S --noconfirm aide'
-  fix_sudo: false
-  affected_file: N/A
-  post_action: Run 'sudo aideinit' (Debian/Ubuntu) or 'sudo aide --init' (RHEL-family/Arch) to initialize the baseline database.
-  security_level: baseline
-  risk_level: low
-  risk_desc: Installation is low risk; initialization consumes CPU/IO.
-- id: pkg-verify-checksums
-  description: Verify installed package files against original metadata (RPM/Deb/Pacman).
-  command: |
-    if command -v rpm >/dev/null; then sudo rpm -Va | grep -v '^..c' | wc -l;
-    elif command -v debsums >/dev/null; then sudo debsums -c 2>&1 | wc -l;
-    elif command -v pacman >/dev/null; then sudo pacman -Qk | grep -v '0 missing files' | wc -l;
-    else echo 0; fi
-  expected: 0
-  sudo: true
-  fix: 'Manual action required: Review identified files. If they are not intentional configuration changes, reinstall the
-    affected package.'
-  fix_sudo: false
-  affected_file: System-wide
-  post_action: None
-  security_level: high
-  risk_level: medium
-  risk_desc: Manual review is mandatory; reinstallation may disrupt services.
-
----
-
-title: Protecting Single User Mode
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- boot
-checksuites:
-- id: rescue-service-authentication
-  description: Ensure authentication is required when entering rescue mode (systemd).
-  command: |
-    grep -E '^ExecStart=.\*sulogin' /usr/lib/systemd/system/rescue.service /lib/systemd/system/rescue.service | wc -l
-  expected: '1'
-  sudo: false
-  fix: 'Manual action required: Create a systemd override for rescue.service to force the use of sulogin.'
-  fix_sudo: true
-  affected_file: /etc/systemd/system/rescue.service.d/override.conf
-  post_action: 'Reload systemd daemon: systemctl daemon-reload'
-  security_level: high
-  risk_level: medium
-  risk_desc: If the root password is lost or forgotten, legitimate administrators will be unable to access rescue mode to
-    recover the system without using a boot loader exploit (init=/bin/bash).
-- id: emergency-service-authentication
-  description: Ensure authentication is required when entering emergency mode (systemd).
-  command: |
-    grep -E '^ExecStart=.\*sulogin' /usr/lib/systemd/system/emergency.service /lib/systemd/system/emergency.service | wc -l
-  expected: '1'
-  sudo: false
-  fix: 'Manual action required: Create a systemd override for emergency.service to force the use of sulogin.'
-  fix_sudo: true
-  affected_file: /etc/systemd/system/emergency.service.d/override.conf
-  post_action: 'Reload systemd daemon: systemctl daemon-reload'
-  security_level: high
-  risk_level: medium
-  risk_desc: If the root password is lost, access to emergency mode will be blocked without external boot media.
-- id: legacy-sysvinit-single-mode
-  description: Ensure authentication is required for single user mode on legacy SysVinit systems (RHEL6/CentOS6 era).
-  command: if [ -f /etc/sysconfig/init ]; then grep '^SINGLE=/sbin/sulogin' /etc/sysconfig/init | wc -l; else echo 1; fi
-  expected: '1'
-  sudo: false
-  fix: Edit /etc/sysconfig/init and set SINGLE=/sbin/sulogin
-  fix_sudo: true
-  affected_file: /etc/sysconfig/init
-  post_action: None
-  security_level: baseline
-  risk_level: low
-  risk_desc: Only applies to legacy systems. Risk is minimal provided the root password is known.
-
----
-
-title: Disable Ctrl-Alt-Del Reboot Sequence
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- boot
-checksuites:
-- id: ctrl-alt-del-masked
-  description: Verify that the Ctrl-Alt-Del reboot sequence is disabled by masking the systemd target.
-  command: systemctl is-enabled ctrl-alt-del.target 2>/dev/null | grep -cE '^masked$'
-  expected: 1
-  sudo: false
-  fix: sudo ln -sf /dev/null /etc/systemd/system/ctrl-alt-del.target && sudo systemctl daemon-reload
-  fix_sudo: true
-  affected_file: /etc/systemd/system/ctrl-alt-del.target
-  post_action: None
-  security_level: baseline
-  risk_level: low
-  risk_desc: Prevents accidental or unauthorized reboots from the physical keyboard.
-
----
-
-title: CPU Microcode Updates
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- boot
-checksuites:
-- id: microcode-revision-runtime
-  description: Verify that a non-zero microcode revision (indicating a successful update over the default BIOS version) is
-    loaded in the running CPU.
-  command: grep -m 1 'microcode' /proc/cpuinfo | awk '{print $NF}' | grep -c '0x[1-9a-fA-F][0-9a-fA-F]*'
-  expected: 1
-  sudo: false
-  fix: 'Manual action required: If the microcode package is installed but this check fails, ensure the initramfs/initrd was
-    updated (e.g., sudo update-initramfs -u) and the system rebooted.'
-  fix_sudo: true
-  affected_file: Kernel runtime status
-  post_action: None
-  security_level: baseline
-  risk_level: low
-  risk_desc: This is a verification check and does not alter the system state.
-- id: vulnerability-mitigation-status
-  description: Verify that the system is reporting successful mitigation for critical hardware vulnerabilities, such as Spectre
-    V2, which requires microcode patches.
-  command: cat /sys/devices/system/cpu/vulnerabilities/spectre_v2 2>/dev/null | grep -c 'Mitigation:'
-  expected: 1
-  expected_op: '>='
-  sudo: false
-  fix: 'Manual action required: Ensure the microcode package is installed, the kernel is patched, and that all kernel command
-    line parameters are correctly configured.'
-  fix_sudo: true
-  affected_file: Kernel runtime status
-  post_action: None
-  security_level: high
-  risk_level: low
-  risk_desc: This is a verification check and relies on the kernel's ability to report mitigation status.
-
----
-
-title: Install and Configure USBGuard
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- services
-checksuites:
-- id: usbguard-service-active
-  description: Verify that the USBGuard service is installed, enabled, and running to enforce USB device policies.
-  requires_command: usbguard
-  command: systemctl is-active usbguard
-  expected: active
-  sudo: true
-  fix: 'Manual action required: Install the usbguard package if not present, then run: sudo systemctl enable --now usbguard'
-  fix_sudo: false
-  affected_file: /etc/usbguard/rules.conf
-  post_action: None
-  security_level: high
-  risk_level: high
-  risk_desc: Incorrectly configured policies can prevent input devices (keyboard, mouse) from functioning, leading to a system
-    lockout.
-- id: usbguard-policy-exists
-  description: Verify that a restrictive default policy is configured in /etc/usbguard/rules.conf.
-  command: grep -c "^block$" /etc/usbguard/rules.conf
-  expected: '1'
-  expected_op: '>='
-  sudo: true
-  fix: 'Manual action required: Establish a baseline policy allowing only authorized devices and ending with a block rule.'
-  fix_sudo: false
-  affected_file: /etc/usbguard/rules.conf
-  post_action: None
-  security_level: high
-  risk_level: high
-  risk_desc: Automatic creation of a restrictive policy may block required devices or disrupt workflows.
-
----
-
-title: Securing the Path Environment Variable
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- auth
-checksuites:
-- id: 80-fs-09-path-writable
-  description: Verify that standard system PATH directories are not globally writable by non-privileged users.
-  command: find /usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin -type d -perm /0002 2>/dev/null | wc -l
-  expected: 0
-  sudo: false
-  fix: 'Manual action required: Identify the writable directory and remove the world-writable bit using `sudo chmod o-w <path>`.'
-  fix_sudo: true
-  affected_file: System PATH directories
-  post_action: None
-  security_level: high
-  risk_level: medium
-  risk_desc: Modifying permissions on critical system directories can lead to system instability.
-
----
-
-title: Enforce Restrictive Default Umask
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- filesystem
-checksuites:
-- id: 81-fs-10-umask-login-defs
-  description: Verify that the default system-wide umask in /etc/login.defs is set to 027 or stricter.
-  command: |
-    grep -E '^\s*UMASK\s+0(27|77)' /etc/login.defs | wc -l
-  expected: 1
-  sudo: false
-  fix: sudo sed -i 's/^UMASK.*/UMASK 027/' /etc/login.defs
-  fix_sudo: true
-  affected_file: /etc/login.defs
-  post_action: None
-  security_level: baseline
-  risk_level: low
-  risk_desc: Affects newly created accounts; does not retroactively change existing user files.
-- id: 82-fs-11-umask-profile
-  description: Verify that the umask for Bourne-style shells is set to 027 or stricter in /etc/profile.
-  command: |
-    grep -E '^\s*umask\s+0(27|77)' /etc/profile | wc -l
-  expected: 1
-  expected_op: '>='
-  sudo: false
-  fix: 'Manual action required: Add ''umask 027'' to /etc/profile. Use conditional logic to avoid breaking root functionality
-    if necessary.'
-  fix_sudo: true
-  affected_file: /etc/profile
-  post_action: Settings take effect upon next login.
-  security_level: baseline
-  risk_level: medium
-  risk_desc: Global umask changes can lead to permission issues in shared environments or scripts.
-
----
-
-title: Partitioning and Mount Options
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- filesystem
-checksuites:
-- id: separate-partition-tmp
-  description: Ensure /tmp is located on a separate partition to prevent resource exhaustion.
-  command: findmnt -n /tmp
-  expected: .+
-  sudo: false
-  fix: 'Manual action required: Create a separate partition for /tmp. This involves disk re-partitioning and fstab modification.'
-  fix_sudo: true
-  affected_file: /etc/fstab
-  post_action: System restart required.
-  security_level: high
-  risk_level: high
-  risk_desc: Manual partitioning carries a high risk of data loss if performed incorrectly.
-- id: mount-options-tmp
-  description: Ensure /tmp is mounted with nodev, nosuid, and noexec.
-  command: findmnt -n -k /tmp | grep -E 'nodev' | grep -E 'nosuid' | grep -E 'noexec' | wc -l
-  expected: '1'
-  sudo: false
-  fix: 'Manual action required: Edit /etc/fstab, add ''nodev,nosuid,noexec'' to /tmp options, and remount.'
-  fix_sudo: true
-  affected_file: /etc/fstab
-  post_action: mount -o remount /tmp
-  security_level: baseline
-  risk_level: medium
-  risk_desc: May break applications that require execution permission in /tmp (e.g., specific installers).
-- id: 38-fs-05-sticky-bit
-  description: Ensure the Sticky Bit is set on all world-writable directories.
-  command: find / -xdev -type d \( -perm -0002 -a ! -perm -1000 \) | wc -l
-  expected: 0
-  sudo: true
-  fix: find / -xdev -type d \( -perm -0002 -a ! -perm -1000 \) -exec chmod +t {} \;
-  fix_sudo: true
-  affected_file: Multiple Directories
-  post_action: None
-  security_level: baseline
-  risk_level: low
-  risk_desc: Prevents users from deleting each other's files in shared directories.
-- id: mount-options-dev-shm
-  description: Ensure /dev/shm is mounted with nodev, nosuid, and noexec.
-  command: findmnt -n -k /dev/shm | grep -E 'nodev' | grep -E 'nosuid' | grep -E 'noexec' | wc -l
-  expected: '1'
-  sudo: false
-  fix: 'Manual action required: Update /etc/fstab with ''nodev,nosuid,noexec'' for the tmpfs mount.'
-  fix_sudo: true
-  affected_file: /etc/fstab
-  post_action: mount -o remount /dev/shm
-  security_level: baseline
-  risk_level: low
-  risk_desc: Minimal impact; shared memory rarely requires binary execution.
-- id: mount-options-home
-  description: Ensure /home is mounted with nodev and nosuid.
-  command: findmnt -n -k /home | grep -E 'nodev' | grep -E 'nosuid' | wc -l
-  expected: '1'
-  sudo: false
-  fix: 'Manual action required: Add ''nodev,nosuid'' to /home in /etc/fstab.'
-  fix_sudo: true
-  affected_file: /etc/fstab
-  post_action: mount -o remount /home
-  security_level: baseline
-  risk_level: low
-  risk_desc: Restricts SUID binaries in user directories.
-
----
-
-title: Enforcing Restrictive Mount Options
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- filesystem
-checksuites:
-- id: mount-tmp-hardening
-  description: 'Verify that the /tmp filesystem is mounted with the mandatory restrictive options: nodev, nosuid, and noexec.'
-  command: findmnt -n /tmp | grep -cE 'nodev.*nosuid.*noexec'
-  expected: 1
-  sudo: false
-  fix: 'Manual action required: Edit /etc/fstab and ensure the /tmp entry includes the options ''nodev,nosuid,noexec''. Then
-    run ''sudo mount -o remount /tmp''.'
-  fix_sudo: true
-  affected_file: /etc/fstab
-  post_action: Remount the filesystem (sudo mount -o remount /tmp) or reboot the system.
-  security_level: high
-  risk_level: medium
-  risk_desc: Applying 'noexec' to temporary directories can break applications or build tools that depend on executing files
-    from /tmp or /var/tmp.
-- id: mount-home-hardening
-  description: Verify that the /home filesystem (or corresponding user partition) is mounted with the 'nodev' and 'nosuid'
-    options.
-  command: findmnt -n /home | grep -cE 'nodev.*nosuid'
-  expected: 1
-  sudo: false
-  fix: 'Manual action required: Edit /etc/fstab and ensure the /home entry includes the options ''nodev,nosuid''. Then run
-    ''sudo mount -o remount /home''.'
-  fix_sudo: true
-  affected_file: /etc/fstab
-  post_action: Remount the filesystem (sudo mount -o remount /home) or reboot the system.
-  security_level: baseline
-  risk_level: low
-  risk_desc: This is a standard security measure and should not affect regular user activities, only preventing malicious
-    file creation/execution.
-
----
-
-title: Hardening the Proc Filesystem
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- kernel
-checksuites:
-- id: proc-hidepid-configured
-  description: Verify that the /proc filesystem is configured in /etc/fstab to use the 'hidepid=2' mount option to restrict
-    process visibility.
-  command: grep -c 'proc /proc proc .*hidepid=2' /etc/fstab
-  expected: 1
-  sudo: false
-  fix: 'Manual action required: Edit /etc/fstab and ensure the /proc entry includes the mandatory option ''hidepid=2''. Then
-    run ''sudo mount -o remount /proc''.'
-  fix_sudo: true
-  affected_file: /etc/fstab
-  post_action: Remount the /proc filesystem (sudo mount -o remount /proc) or reboot the system.
-  security_level: high
-  risk_level: medium
-  risk_desc: Restricting process visibility can interfere with system monitoring tools (e.g., automated checks, centralized
-    monitoring agents) and user-facing utilities (e.g., 'ps', 'top'). Thorough testing is required.
-- id: proc-hidepid-runtime
-  description: Verify that the /proc filesystem is currently mounted with the 'hidepid=2' option enforced at runtime.
-  command: findmnt -n /proc | grep -c 'hidepid=2'
-  expected: 1
-  sudo: false
-  fix: 'Manual action required: Run ''sudo mount -o remount /proc'' to apply the setting from /etc/fstab, or reboot the system.'
-  fix_sudo: true
-  affected_file: Kernel runtime status
-  post_action: None
-  security_level: high
-  risk_level: low
-  risk_desc: This is purely a verification check; no runtime risk is introduced.
-
----
-
-title: Audit and Restrict SUID/SGID Executables
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- filesystem
-checksuites:
-- id: suid-sgid-file-count
-  description: Audit the number of files with the SUID or SGID permission bits set. This count must be monitored to detect
-    unauthorized changes.
-  command: sudo find / -xdev -type f -perm /06000 2>/dev/null | wc -l
-  expected: 150
-  expected_op: <=
-  sudo: true
-  fix: 'Manual action required: Review the list generated by the audit command, identify unnecessary binaries, and remove
-    the bits using ''sudo chmod u-s,g-s <file>''. WARNING: Do NOT remove SUID from essential binaries like /usr/bin/passwd
-    or /usr/bin/sudo.'
-  fix_sudo: true
-  affected_file: System executables
-  post_action: Perform functional testing of critical services (sudo, passwd, mount) to ensure required SUID binaries are
-    intact.
-  security_level: high
-  risk_level: high
-  risk_desc: Removing the SUID/SGID bit from essential system executables (e.g., 'sudo', 'mount', 'passwd') will immediately
-    break core system functionality and may lead to a loss of administrative control.
-- id: find-binary-not-suid
-  description: Verify that the 'find' utility binary itself does not have the SUID bit set, preventing potential misuse during
-    filesystem traversal.
-  # Use `command -v` (POSIX, unlike `which` which isn't always installed on Arch
-  # minimal), then test the SUID bit directly with `find -perm -4000` instead of
-  # the previous `grep -c '4'` which incorrectly counted any digit '4' in the mode.
-  command: |
-    fp=$(command -v find 2>/dev/null || echo /usr/bin/find)
-    [ -e "$fp" ] || { echo 0; exit 0; }
-    find "$fp" -perm -4000 2>/dev/null | wc -l
-  expected: 0
-  sudo: false
-  fix: |
-    fp=$(command -v find 2>/dev/null || echo /usr/bin/find)
-    sudo chmod u-s "$fp"
-  fix_sudo: true
-  affected_file: /usr/bin/find
-  post_action: None
-  security_level: baseline
-  risk_level: low
-  risk_desc: Removing the SUID bit from the 'find' utility is a standard security measure and should not affect its normal
-    function.
-
----
-
-title: World Writable File and Directory Audit
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- filesystem
-checksuites:
-- id: 83-fs-12-audit-world-writable-files
-  description: Audit regular files with the world-writable bit set to prevent unauthorized modification.
-  command: sudo find / -xdev -type f -perm -0002 2>/dev/null | wc -l
-  expected: 0
-  sudo: true
-  fix: 'Manual action required: Remove the world-writable bit using `sudo chmod o-w <file>` after verifying the file purpose.'
-  fix_sudo: true
-  affected_file: System files
+  affected_file: /var/log/journal
   post_action: None.
-  security_level: high
+  security_level: baseline
   risk_level: low
-  risk_desc: Standard files should never be world-writable; remediation secures system integrity.
-- id: 84-fs-13-audit-world-writable-directories
-  description: Audit directories (excluding temporary paths) that are writable by the world.
-  command: sudo find / -xdev -type d -perm -0002 -not -path '/tmp' -not -path '/var/tmp' -not -path '/dev/shm' 2>/dev/null
-    | wc -l
-  expected: 0
-  sudo: true
-  fix: 'Manual action required: Remove the world-writable bit using `sudo chmod o-w <directory>`.'
-  fix_sudo: true
-  affected_file: System directories
-  post_action: None.
-  security_level: high
-  risk_level: low
-  risk_desc: Misconfigured directories can allow attackers to plant malicious scripts.
+  risk_desc: Incorrect permissions could expose sensitive log data to local users, but the fix is a standard corrective measure.
 
 ---
-
-title: Audit and Remediate Unowned and Ungrouped Files
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- filesystem
-checksuites:
-- id: audit-files-no-user
-  description: Audit all files on local filesystems that are owned by a numeric UID not defined in /etc/passwd (no valid user).
-  command: sudo find / -xdev -nouser 2>/dev/null | wc -l
-  expected: 0
-  sudo: true
-  fix: 'Manual action required: Review the files and either delete the obsolete files or reassign ownership to a valid system
-    user, e.g., ''sudo chown root <file>'''
-  fix_sudo: true
-  affected_file: Filesystem metadata
-  post_action: None. This is a housekeeping task.
-  security_level: baseline
-  risk_level: low
-  risk_desc: This remediation is a low-risk integrity cleanup that prevents UID reassignment from granting unauthorized ownership.
-- id: audit-files-no-group
-  description: Audit all files on local filesystems that are owned by a numeric GID not defined in /etc/group (no valid group).
-  command: sudo find / -xdev -nogroup 2>/dev/null | wc -l
-  expected: 0
-  sudo: true
-  fix: 'Manual action required: Review the files and either delete the obsolete files or reassign group ownership to a valid
-    system group, e.g., ''sudo chgrp root <file>'''
-  fix_sudo: true
-  affected_file: Filesystem metadata
-  post_action: None. This is a housekeeping task.
-  security_level: baseline
-  risk_level: low
-  risk_desc: This remediation is a low-risk integrity cleanup.
-
----
-
-title: Polyinstantiation of Temporary Directories
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- filesystem
-checksuites:
-- id: pam-namespace-active
-  description: Verify that the pam_namespace.so module is active in the session stack for local logins to initiate directory
-    isolation.
-  command: |
-    grep -cE '^\s*session\s+required\s+pam_namespace.so' /etc/pam.d/login
-  expected: 1
-  sudo: false
-  fix: 'Manual action required: Add the line ''session required pam_namespace.so'' to the session stack in /etc/pam.d/login
-    and /etc/pam.d/sshd.'
-  fix_sudo: true
-  affected_file: /etc/pam.d/login
-  post_action: None. Users must log out and log back in for changes to apply.
-  security_level: high
-  risk_level: medium
-  risk_desc: Incorrect placement of the pam_namespace.so module in the PAM stack can cause login failures, potentially locking
-    out users if not thoroughly tested.
-- id: tmp-polyinstantiation-config
-  description: Verify that /tmp and /var/tmp are configured for user-based polyinstantiation in /etc/security/namespace.conf.
-  command: |
-    grep -cE '^/tmp\s+tmpfs\s+user\s+create' /etc/security/namespace.conf
-  expected: 1
-  sudo: false
-  fix: 'Manual action required: Add the required polyinstantiation lines to /etc/security/namespace.conf for /tmp and /var/tmp.'
-  fix_sudo: true
-  affected_file: /etc/security/namespace.conf
-  post_action: None.
-  security_level: high
-  risk_level: high
-  risk_desc: This feature can break applications that rely on a globally shared /tmp for inter-process communication (IPC)
-    between different user sessions or services.
-
----
-
-title: Audit Framework Installation and Setup
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- audit
-checksuites:
-- id: auditd-package-installed
-  description: Verify that the auditd daemon binary is present, providing the Linux Auditing Framework.
-  command: command -v auditd >/dev/null 2>&1 && echo 1 || echo 0
-  expected: 1
-  sudo: false
-  fix: 'Manual action required: Install auditd. Debian/Ubuntu: sudo apt install auditd | RHEL/Rocky/Fedora: sudo dnf
-    install -y audit | SUSE: sudo zypper install -y audit | Arch: sudo pacman -S --noconfirm audit'
-  fix_sudo: false
-  affected_file: N/A
-  post_action: None
-  security_level: baseline
-  risk_level: low
-  risk_desc: Installing auditd is a prerequisite for security monitoring and does not affect system stability.
-- id: auditd-service-enabled
-  description: Verify that the auditd service is enabled to ensure that the auditing framework starts automatically upon system
-    boot.
-  requires_command: auditctl
-  command: systemctl is-enabled auditd
-  expected: enabled
-  sudo: false
-  fix: sudo systemctl enable auditd
-  fix_sudo: true
-  affected_file: System service configuration
-  post_action: None
-  security_level: baseline
-  risk_level: low
-  risk_desc: Enabling the service is essential for persistent security monitoring and poses a minimal risk.
-- id: auditd-service-active
-  description: Verify that the auditd service is currently running actively to ensure continuous security event logging.
-  requires_command: auditctl
-  command: systemctl is-active auditd
-  expected: active
-  sudo: false
-  fix: sudo systemctl start auditd
-  fix_sudo: true
-  affected_file: System service runtime
-  post_action: None
-  security_level: baseline
-  risk_level: low
-  risk_desc: Starting the service introduces a slight performance overhead, but the security benefits are mandatory.
-
----
-
-title: Audit Rules for Identity and Privilege Escalation
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- audit
-checksuites:
-- id: audit-identity-file-changes
-  description: Verify rules exist to monitor all write and attribute changes to critical identity files (/etc/passwd, /etc/shadow,
-    /etc/sudoers).
-  command: |
-    grep -cE '^\s*-w\s+/etc/shadow\s+-p\s+wa' /etc/audit/rules.d/*.rules
-  expected: 1
-  sudo: false
-  distro:
-    debian:
-      command: |
-        grep -rcE '^\s*-w\s+/etc/shadow\s+-p\s+wa' /etc/audit/rules.d/
-      sudo: true
-  fix: 'Manual action required: Add rules to monitor all critical identity files for write access (wa). See text for full
-    list of mandatory rules.'
-  fix_sudo: true
-  affected_file: /etc/audit/rules.d/90-identity.rules
-  post_action: |
-    Run 'sudo auditctl -R' to load the new ruleset immediately.
-  security_level: baseline
-  risk_level: low
-  risk_desc: Incorrect audit rules may fail to log critical events, but will not affect system stability.
-- id: audit-privilege-executables
-  description: Verify rules exist to monitor the successful execution of privilege escalation binaries (su and sudo).
-  command: |
-    grep -cE '^\s*-a\s+always,exit\s+-F\s+path=/usr/bin/su' /etc/audit/rules.d/*.rules
-  expected: 1
-  sudo: false
-  distro:
-    debian:
-      command: |
-        grep -rcE '^\s*-a\s+always,exit\s+-F\s+path=/usr/bin/su' /etc/audit/rules.d/
-      sudo: true
-  fix: 'Manual action required: Add execution monitoring rules for /usr/bin/su and /usr/bin/sudo.'
-  fix_sudo: true
-  affected_file: /etc/audit/rules.d/90-identity.rules
-  post_action: |
-    Run 'sudo auditctl -R' to load the new ruleset immediately.
-  security_level: baseline
-  risk_level: low
-  risk_desc: Monitoring execution of binaries is low risk, but failure to monitor may allow an attacker to escalate privileges
-    without detection.
-
----
-
-title: Audit Rules for System Integrity and File Access
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- audit
-checksuites:
-- id: audit-file-attribute-changes
-  description: Verify rules exist to monitor critical syscalls that modify file permissions and ownership (e.g., chmod, chown).
-  command: |
-    grep -cE '^\s*-a\s+always,exit\s+-S\s+chmod' /etc/audit/rules.d/*.rules
-  expected: 1
-  sudo: false
-  distro:
-    debian:
-      command: |
-        grep -rcE '^\s*-a\s+always,exit\s+-S\s+chmod' /etc/audit/rules.d/
-      sudo: true
-  fix: 'Manual action required: Add the mandatory syscall rules for file attribute changes. See text for full list of syscalls.'
-  fix_sudo: true
-  affected_file: /etc/audit/rules.d/91-system-access.rules
-  post_action: |
-    Run 'sudo auditctl -R' to load the new ruleset immediately.
-  security_level: baseline
-  risk_level: low
-  risk_desc: Monitoring file access syscalls is essential for detecting tampering and poses a negligible performance risk.
-- id: audit-file-deletion-activity
-  description: Verify rules exist to monitor syscalls related to file and directory deletion (e.g., unlink, rmdir) across
-    the filesystem.
-  command: |
-    grep -cE '^\s*-a\s+always,exit\s+-S\s+unlink' /etc/audit/rules.d/*.rules
-  expected: 1
-  sudo: false
-  distro:
-    debian:
-      command: |
-        grep -rcE '^\s*-a\s+always,exit\s+-S\s+unlink' /etc/audit/rules.d/
-      sudo: true
-  fix: 'Manual action required: Add the mandatory syscall rules for file deletion/renaming.'
-  fix_sudo: true
-  affected_file: /etc/audit/rules.d/91-system-access.rules
-  post_action: |
-    Run 'sudo auditctl -R' to load the new ruleset immediately.
-  security_level: baseline
-  risk_level: low
-  risk_desc: This monitoring is essential for forensic analysis after a file integrity violation.
-- id: audit-kernel-module-loading
-  description: Verify rules exist to monitor kernel integrity by logging attempts to load or unload kernel modules (init_module,
-    delete_module).
-  command: |
-    grep -cE '^\s*-a\s+always,exit\s+-S\s+init_module' /etc/audit/rules.d/*.rules
-  expected: 1
-  sudo: false
-  fix: 'Manual action required: Add the syscall rules for kernel module management.'
-  fix_sudo: true
-  affected_file: /etc/audit/rules.d/91-system-access.rules
-  post_action: |
-    Run 'sudo auditctl -R' to load the new ruleset immediately.
-  security_level: high
-  risk_level: low
-  risk_desc: Monitoring kernel module activity is critical for detecting rootkits and poses zero performance overhead.
-
----
-
-title: Enforcing Immutable Audit Configuration
-os: linux
-arch:
-- amd64
-- arm64
-labels:
-- audit
-checksuites:
-- id: audit-immutable-rule-config
-  description: Verify that the mandatory rule to set the audit configuration to immutable is the last line in the ruleset.
-  command: sudo tail -n 1 /etc/audit/rules.d/99-finalize.rules 2>/dev/null | grep -c '^-e 2'
-  expected: 1
-  sudo: true
-  fix: echo '-e 2' | sudo tee /etc/audit/rules.d/99-finalize.rules
-  fix_sudo: true
-  affected_file: /etc/audit/rules.d/99-finalize.rules
-  post_action: A system reboot is MANDATORY to load the immutable rule and lock the configuration.
-  security_level: high
-  risk_level: high
-  risk_desc: Once set to immutable, the audit rules cannot be changed or cleared without a system reboot. This creates a risk
-    if the ruleset is flawed and causes a Denial of Service (DoS) due to excessive logging.
-- id: audit-immutable-mode-runtime
-  description: Verify that the kernel's audit system is currently operating in immutable mode, preventing runtime tampering.
-  command: sudo auditctl -s | grep -c 'enabled 2'
-  expected: 1
-  sudo: true
-  fix: 'Manual action required: Reboot the system to ensure the immutable rule is loaded by the auditd service.'
-  fix_sudo: true
-  affected_file: Kernel runtime status
-  post_action: None
-  security_level: high
-  risk_level: low
-  risk_desc: This is purely a verification check for the most critical audit security feature.
-
----
-
 title: Syslog Daemon Hardening
 os: linux
 arch:
@@ -2341,7 +2213,11 @@ checksuites:
 - id: syslog-network-disabled
   description: Verify that the syslog daemon (e.g., rsyslog) is not listening on network ports (UDP 514, TCP 601) unless explicitly
     configured as a log collector.
-  command: ss -tuln | grep -cE '514|601'
+  command: |
+    command -v ss >/dev/null 2>&1 || { echo 0; exit 0; }
+    ss -tuln 2>/dev/null \
+      | awk 'NR>1 { n=split($5,a,":"); p=a[n]; if (p==514 || p==601) print }' \
+      | wc -l
   expected: 0
   sudo: true
   fix: 'Manual action required: Comment out or remove network receiver module directives (e.g., $ModLoad imudp, $ModLoad imtcp)
@@ -2354,9 +2230,13 @@ checksuites:
   risk_desc: Disabling network listening reduces attack surface and does not impact local logging functionality.
 - id: syslog-critical-file-permissions
   description: Verify that the primary security log file has restrictive permissions (0640 or tighter). The file path differs
-    by distro — /var/log/auth.log on Debian/Ubuntu, /var/log/secure on RHEL-family, /var/log/messages on SUSE, and
+    by distro, with /var/log/auth.log on Debian/Ubuntu, /var/log/secure on RHEL-family, /var/log/messages on SUSE, and
     either (or neither, if only journald is used) on Arch.
-  command: stat -c '%a' /var/log/auth.log 2>/dev/null
+  command: |
+    for f in /var/log/auth.log /var/log/secure; do
+      [ -e "$f" ] && { stat -c '%a' "$f"; exit 0; }
+    done
+    echo missing
   expected: 640
   expected_op: <=
   sudo: false
@@ -2384,7 +2264,8 @@ checksuites:
 - id: syslog-dir-permissions
   description: Verify that the primary log directory /var/log has restrictive permissions (0755 or tighter) to prevent unauthorized
     file creation or directory modification.
-  command: stat -c '%a' /var/log
+  command: |
+    stat -c '%a' /var/log 2>/dev/null || echo missing
   expected: 755
   expected_op: <=
   sudo: false
@@ -2397,95 +2278,261 @@ checksuites:
   risk_desc: This is a standard file permission hardening measure.
 
 ---
-
-title: Systemd Journal Hardening and Integrity
+title: Audit Framework Installation and Setup
 os: linux
 arch:
 - amd64
 - arm64
 labels:
-- logging
+- audit
 checksuites:
-- id: journald-persistent-storage
-  description: Verify that journal storage is set to 'persistent' to retain forensic logs across reboots.
-  command: grep -c '^Storage=persistent' /etc/systemd/journald.conf 2>/dev/null
-  expected: '1'
+- id: auditd-package-installed
+  description: Verify that the auditd daemon binary is present, providing the Linux Auditing Framework.
+  command: command -v auditd >/dev/null 2>&1 && echo 1 || echo 0
+  expected: 1
   sudo: false
-  fix: |
-    sudo sed -i 's/^#\?Storage=.*/Storage=persistent/' /etc/systemd/journald.conf
-  fix_sudo: true
-  affected_file: /etc/systemd/journald.conf
-  post_action: 'Restart journald: sudo systemctl restart systemd-journald'
+  fix: 'Manual action required: Install auditd. Debian/Ubuntu: sudo apt install auditd | RHEL/Rocky/Fedora: sudo dnf
+    install -y audit | SUSE: sudo zypper install -y audit | Arch: sudo pacman -S --noconfirm audit'
+  fix_sudo: false
+  affected_file: N/A
+  post_action: None
   security_level: baseline
   risk_level: low
-  risk_desc: Changing storage creates the /var/log/journal directory, which is necessary for forensic integrity.
-- id: journald-compression-enabled
-  description: Verify that log compression is not explicitly disabled (default is enabled).
-  command: grep -c '^Compress=no' /etc/systemd/journald.conf 2>/dev/null
-  expected: '0'
+  risk_desc: Installing auditd is a prerequisite for security monitoring and does not affect system stability.
+- id: auditd-service-enabled
+  description: Verify that the auditd service is enabled to ensure that the auditing framework starts automatically upon system
+    boot.
+  requires_command: auditctl
+  command: |
+    out=$(systemctl is-enabled auditd 2>/dev/null)
+    echo "${out:-disabled}"
+  expected: enabled
   sudo: false
-  fix: |
-    sudo sed -i 's/^#\\?Compress=.*/Compress=yes/' /etc/systemd/journald.conf
+  fix: sudo systemctl enable auditd
   fix_sudo: true
-  affected_file: /etc/systemd/journald.conf
-  post_action: 'Restart journald: sudo systemctl restart systemd-journald'
+  affected_file: System service configuration
+  post_action: None
   security_level: baseline
   risk_level: low
-  risk_desc: Compression saves disk space and does not affect log integrity.
-- id: journald-persistent-dir-perms
-  description: Verify that the persistent journal directory (/var/log/journal) has restrictive permissions (e.g., 2755) and
-    the SetGID bit set.
-  command: stat -c '%a' /var/log/journal 2>/dev/null
-  expected: 2755
-  expected_op: <=
+  risk_desc: Enabling the service is essential for persistent security monitoring and poses a minimal risk.
+- id: auditd-service-active
+  description: Verify that the auditd service is currently running actively to ensure continuous security event logging.
+  requires_command: auditctl
+  command: |
+    out=$(systemctl is-active auditd 2>/dev/null)
+    echo "${out:-inactive}"
+  expected: active
   sudo: false
-  fix: sudo chmod 2755 /var/log/journal
+  fix: sudo systemctl start auditd
   fix_sudo: true
-  affected_file: /var/log/journal
-  post_action: None.
+  affected_file: System service runtime
+  post_action: None
   security_level: baseline
   risk_level: low
-  risk_desc: Incorrect permissions could expose sensitive log data to local users, but the fix is a standard corrective measure.
+  risk_desc: Starting the service introduces a slight performance overhead, but the security benefits are mandatory.
 
 ---
-
-title: Cron Security
+title: Audit Rules for Identity and Privilege Escalation
 os: linux
 arch:
 - amd64
 - arm64
 labels:
-- services
+- audit
 checksuites:
-- id: cron_only_root_allowed
-  description: Ensure that only the root user is allowed to schedule cron jobs by using a restrictive /etc/cron.allow file.
-  command: if [ -f /etc/cron.allow ] && grep -q '^root$' /etc/cron.allow 2>/dev/null && [ ! -f /etc/cron.deny ]; then echo 1; else echo 0; fi
-  expected: '1'
-  sudo: true
-  fix: rm -f /etc/cron.deny; echo "root" > /etc/cron.allow; chmod 0640 /etc/cron.allow; chown root:root /etc/cron.allow
+- id: audit-identity-file-changes
+  description: Verify rules exist to monitor all write and attribute changes to critical identity files (/etc/passwd, /etc/shadow,
+    /etc/sudoers).
+  command: |
+    grep -hE '^[[:space:]]*-w[[:space:]]+/etc/shadow[[:space:]]+-p[[:space:]]+[rwxa]*w[rwxa]*a' \
+      /etc/audit/rules.d/*.rules 2>/dev/null | wc -l
+  expected: 1
+  expected_op: '>='
+  sudo: false
+  distro:
+    debian:
+      command: |
+        grep -rcE '^\s*-w\s+/etc/shadow\s+-p\s+wa' /etc/audit/rules.d/
+      sudo: true
+  fix: 'Manual action required: Add rules to monitor all critical identity files for write access (wa). See text for full
+    list of mandatory rules.'
   fix_sudo: true
-  affected_file: /etc/cron.allow
-  post_action: None
+  affected_file: /etc/audit/rules.d/90-identity.rules
+  post_action: |
+    Run 'sudo auditctl -R' to load the new ruleset immediately.
   security_level: baseline
   risk_level: low
-  risk_desc: Restricting cron access to only root may prevent legitimate, non-privileged users from scheduling necessary tasks.
-    These users will need to request that root or an authorized admin set up the job.
-- id: at_only_root_allowed
-  description: Ensure that only the root user is allowed to schedule at jobs by using a restrictive /etc/at.allow file.
-  command: if [ -f /etc/at.allow ] && grep -q '^root$' /etc/at.allow 2>/dev/null && [ ! -f /etc/at.deny ]; then echo 1; else echo 0; fi
-  expected: '1'
-  sudo: true
-  fix: rm -f /etc/at.deny; echo "root" > /etc/at.allow; chmod 0640 /etc/at.allow; chown root:root /etc/at.allow
+  risk_desc: Incorrect audit rules may fail to log critical events, but will not affect system stability.
+- id: audit-privilege-executables
+  description: Verify rules exist to monitor the successful execution of privilege escalation binaries (su and sudo).
+  command: |
+    grep -hE '^[[:space:]]*-a[[:space:]]+always,exit\b.*-F[[:space:]]+path=/usr/bin/su\b' \
+      /etc/audit/rules.d/*.rules 2>/dev/null | wc -l
+  expected: 1
+  expected_op: '>='
+  sudo: false
+  distro:
+    debian:
+      command: |
+        grep -rcE '^\s*-a\s+always,exit\s+-F\s+path=/usr/bin/su' /etc/audit/rules.d/
+      sudo: true
+  fix: 'Manual action required: Add execution monitoring rules for /usr/bin/su and /usr/bin/sudo.'
   fix_sudo: true
-  affected_file: /etc/at.allow
-  post_action: None
+  affected_file: /etc/audit/rules.d/90-identity.rules
+  post_action: |
+    Run 'sudo auditctl -R' to load the new ruleset immediately.
   security_level: baseline
   risk_level: low
-  risk_desc: Restricting 'at' access to only root may prevent legitimate, non-privileged users from scheduling necessary one-time
-    tasks. These users will need to request admin assistance.
+  risk_desc: Monitoring execution of binaries is low risk, but failure to monitor may allow an attacker to escalate privileges
+    without detection.
+
+---
+title: Audit Rules for System Integrity and File Access
+os: linux
+arch:
+- amd64
+- arm64
+labels:
+- audit
+checksuites:
+- id: audit-file-attribute-changes
+  description: Verify rules exist to monitor critical syscalls that modify file permissions and ownership (e.g., chmod, chown).
+  command: |
+    grep -hE '^[[:space:]]*-a[[:space:]]+always,exit\b.*[[:space:]]-S[[:space:]]+[a-z0-9_,]*\bchmod\b' \
+      /etc/audit/rules.d/*.rules 2>/dev/null | wc -l
+  expected: 1
+  expected_op: '>='
+  sudo: false
+  distro:
+    debian:
+      command: |
+        grep -rcE '^\s*-a\s+always,exit\s+-S\s+chmod' /etc/audit/rules.d/
+      sudo: true
+  fix: 'Manual action required: Add the mandatory syscall rules for file attribute changes. See text for full list of syscalls.'
+  fix_sudo: true
+  affected_file: /etc/audit/rules.d/91-system-access.rules
+  post_action: |
+    Run 'sudo auditctl -R' to load the new ruleset immediately.
+  security_level: baseline
+  risk_level: low
+  risk_desc: Monitoring file access syscalls is essential for detecting tampering and poses a negligible performance risk.
+- id: audit-file-deletion-activity
+  description: Verify rules exist to monitor syscalls related to file and directory deletion (e.g., unlink, rmdir) across
+    the filesystem.
+  command: |
+    grep -hE '^[[:space:]]*-a[[:space:]]+always,exit\b.*[[:space:]]-S[[:space:]]+[a-z0-9_,]*\bunlink\b' \
+      /etc/audit/rules.d/*.rules 2>/dev/null | wc -l
+  expected: 1
+  expected_op: '>='
+  sudo: false
+  distro:
+    debian:
+      command: |
+        grep -rcE '^\s*-a\s+always,exit\s+-S\s+unlink' /etc/audit/rules.d/
+      sudo: true
+  fix: 'Manual action required: Add the mandatory syscall rules for file deletion/renaming.'
+  fix_sudo: true
+  affected_file: /etc/audit/rules.d/91-system-access.rules
+  post_action: |
+    Run 'sudo auditctl -R' to load the new ruleset immediately.
+  security_level: baseline
+  risk_level: low
+  risk_desc: This monitoring is essential for forensic analysis after a file integrity violation.
+- id: audit-kernel-module-loading
+  description: Verify rules exist to monitor kernel integrity by logging attempts to load or unload kernel modules (init_module,
+    delete_module).
+  command: |
+    grep -hE '^[[:space:]]*-a[[:space:]]+always,exit\b.*[[:space:]]-S[[:space:]]+[a-z0-9_,]*\binit_module\b' \
+      /etc/audit/rules.d/*.rules 2>/dev/null | wc -l
+  expected: 1
+  expected_op: '>='
+  sudo: false
+  fix: 'Manual action required: Add the syscall rules for kernel module management.'
+  fix_sudo: true
+  affected_file: /etc/audit/rules.d/91-system-access.rules
+  post_action: |
+    Run 'sudo auditctl -R' to load the new ruleset immediately.
+  security_level: high
+  risk_level: low
+  risk_desc: Monitoring kernel module activity is critical for detecting rootkits and poses zero performance overhead.
+
+---
+title: Enforcing Immutable Audit Configuration
+os: linux
+arch:
+- amd64
+- arm64
+labels:
+- audit
+checksuites:
+- id: audit-immutable-rule-config
+  description: Verify that the mandatory rule to set the audit configuration to immutable is the last line in the ruleset.
+  command: |
+    tail -n 1 /etc/audit/rules.d/99-finalize.rules 2>/dev/null \
+      | grep -xE '[[:space:]]*-e[[:space:]]+2[[:space:]]*' | wc -l
+  expected: 1
+  expected_op: '>='
+  sudo: true
+  fix: echo '-e 2' | sudo tee /etc/audit/rules.d/99-finalize.rules
+  fix_sudo: true
+  affected_file: /etc/audit/rules.d/99-finalize.rules
+  post_action: A system reboot is MANDATORY to load the immutable rule and lock the configuration.
+  security_level: high
+  risk_level: high
+  risk_desc: Once set to immutable, the audit rules cannot be changed or cleared without a system reboot. This creates a risk
+    if the ruleset is flawed and causes a Denial of Service (DoS) due to excessive logging.
+- id: audit-immutable-mode-runtime
+  description: Verify that the kernel's audit system is currently operating in immutable mode, preventing runtime tampering.
+  command: |
+    command -v auditctl >/dev/null 2>&1 || { echo 0; exit 0; }
+    auditctl -s 2>/dev/null | grep -c 'enabled 2' || true
+  expected: 1
+  expected_op: '>='
+  sudo: true
+  fix: 'Manual action required: Reboot the system to ensure the immutable rule is loaded by the auditd service.'
+  fix_sudo: true
+  affected_file: Kernel runtime status
+  post_action: None
+  security_level: high
+  risk_level: low
+  risk_desc: This is purely a verification check for the most critical audit security feature.
 
 ---
 
+title: Mandatory Access Control (MAC) Implementation
+os: linux
+arch:
+- amd64
+- arm64
+labels:
+- auth
+checksuites:
+- id: 85-mac-01-selinux-enforcing
+  description: Verify that SELinux is set to enforcing mode on supported systems (Fedora/RHEL).
+  command: if command -v getenforce >/dev/null; then getenforce; else echo 'Enforcing'; fi
+  expected: Enforcing
+  sudo: false
+  fix: 'Manual action required: Set `SELINUX=enforcing` in `/etc/selinux/config` and reboot.'
+  fix_sudo: true
+  affected_file: /etc/selinux/config
+  post_action: None
+  security_level: high
+  risk_level: high
+  risk_desc: Switching from disabled to enforcing may require a filesystem relabel, which takes time during boot.
+- id: 86-mac-02-apparmor-active
+  description: Verify that AppArmor is active and profiles are enforced (Ubuntu/Debian/Arch/SUSE).
+  command: if command -v aa-status >/dev/null; then sudo aa-status | grep -q 'profiles are in enforce mode' && echo 'active'
+    || echo 'inactive'; else echo 'active'; fi
+  expected: active
+  sudo: true
+  fix: sudo systemctl enable --now apparmor
+  fix_sudo: true
+  affected_file: /etc/apparmor.d/
+  post_action: None
+  security_level: high
+  risk_level: medium
+  risk_desc: Enabling AppArmor might block non-standard applications until a profile is created.
+---
 title: Systemd Service Sandboxing and Resource Control
 os: linux
 arch:
@@ -2536,8 +2583,43 @@ checksuites:
   risk_desc: Isolates /tmp to prevent inter-process information leakage.
 
 ---
+title: Cron Security
+os: linux
+arch:
+- amd64
+- arm64
+labels:
+- services
+checksuites:
+- id: cron_only_root_allowed
+  description: Ensure that only the root user is allowed to schedule cron jobs by using a restrictive /etc/cron.allow file.
+  command: if [ -f /etc/cron.allow ] && grep -q '^root$' /etc/cron.allow 2>/dev/null && [ ! -f /etc/cron.deny ]; then echo 1; else echo 0; fi
+  expected: '1'
+  sudo: true
+  fix: rm -f /etc/cron.deny; echo "root" > /etc/cron.allow; chmod 0640 /etc/cron.allow; chown root:root /etc/cron.allow
+  fix_sudo: true
+  affected_file: /etc/cron.allow
+  post_action: None
+  security_level: baseline
+  risk_level: low
+  risk_desc: Restricting cron access to only root may prevent legitimate, non-privileged users from scheduling necessary tasks.
+    These users will need to request that root or an authorized admin set up the job.
+- id: at_only_root_allowed
+  description: Ensure that only the root user is allowed to schedule at jobs by using a restrictive /etc/at.allow file.
+  command: if [ -f /etc/at.allow ] && grep -q '^root$' /etc/at.allow 2>/dev/null && [ ! -f /etc/at.deny ]; then echo 1; else echo 0; fi
+  expected: '1'
+  sudo: true
+  fix: rm -f /etc/at.deny; echo "root" > /etc/at.allow; chmod 0640 /etc/at.allow; chown root:root /etc/at.allow
+  fix_sudo: true
+  affected_file: /etc/at.allow
+  post_action: None
+  security_level: baseline
+  risk_level: low
+  risk_desc: Restricting 'at' access to only root may prevent legitimate, non-privileged users from scheduling necessary one-time
+    tasks. These users will need to request admin assistance.
 
-title: Mandatory Access Control (MAC) Implementation
+---
+title: Session and Screen Lock Hardening
 os: linux
 arch:
 - amd64
@@ -2545,28 +2627,72 @@ arch:
 labels:
 - auth
 checksuites:
-- id: 85-mac-01-selinux-enforcing
-  description: Verify that SELinux is set to enforcing mode on supported systems (Fedora/RHEL).
-  command: if command -v getenforce >/dev/null; then getenforce; else echo 'Enforcing'; fi
-  expected: Enforcing
+- id: gnome-lock-enabled
+  description: Ensure the GNOME screensaver is configured to lock the screen after a period of inactivity. Only applicable
+    on systems with a GNOME desktop installed (skipped elsewhere) and irrelevant on headless servers regardless of distro,
+    and on Arch/Debian/RHEL-family systems installed without a desktop environment at all.
+  requires_command: gsettings
+  command: gsettings get org.gnome.desktop.screensaver lock-enabled
+  expected: 'true'
   sudo: false
-  fix: 'Manual action required: Set `SELINUX=enforcing` in `/etc/selinux/config` and reboot.'
+  fix: 'Manual action required: Enforce via dconf profile in /etc/dconf/db/local.d/locks/session to prevent user override.'
   fix_sudo: true
-  affected_file: /etc/selinux/config
+  affected_file: /etc/dconf/db/local.d/00-security-settings
+  post_action: Run 'sudo dconf update' to apply system-wide changes.
+  security_level: baseline
+  risk_level: low
+  risk_desc: Essential for physical security in desktop environments.
+- id: gnome-idle-delay
+  description: Ensure the GNOME idle delay is set to 300 seconds (5 minutes) or less. Only applicable on systems with a
+    GNOME desktop installed (skipped elsewhere).
+  requires_command: gsettings
+  command: gsettings get org.gnome.desktop.session idle-delay | awk '{if($2<=300 && $2!=0) print 1; else print 0}'
+  expected: 1
+  sudo: false
+  fix: gsettings set org.gnome.desktop.session idle-delay 300
+  fix_sudo: false
+  affected_file: User GSettings Database
+  post_action: None
+  security_level: baseline
+  risk_level: low
+  risk_desc: Mandatory for compliance in office/shared environments.
+
+---
+title: Install and Configure USBGuard
+os: linux
+arch:
+- amd64
+- arm64
+labels:
+- services
+checksuites:
+- id: usbguard-service-active
+  description: Verify that the USBGuard service is installed, enabled, and running to enforce USB device policies.
+  requires_command: usbguard
+  command: |
+    out=$(systemctl is-active usbguard 2>/dev/null)
+    echo "${out:-inactive}"
+  expected: active
+  sudo: true
+  fix: 'Manual action required: Install the usbguard package if not present, then run: sudo systemctl enable --now usbguard'
+  fix_sudo: false
+  affected_file: /etc/usbguard/rules.conf
   post_action: None
   security_level: high
   risk_level: high
-  risk_desc: Switching from disabled to enforcing may require a filesystem relabel, which takes time during boot.
-- id: 86-mac-02-apparmor-active
-  description: Verify that AppArmor is active and profiles are enforced (Ubuntu/Debian/Arch/SUSE).
-  command: if command -v aa-status >/dev/null; then sudo aa-status | grep -q 'profiles are in enforce mode' && echo 'active'
-    || echo 'inactive'; else echo 'active'; fi
-  expected: active
+  risk_desc: Incorrectly configured policies can prevent input devices (keyboard, mouse) from functioning, leading to a system
+    lockout.
+- id: usbguard-policy-exists
+  description: Verify that a restrictive default policy is configured in /etc/usbguard/rules.conf.
+  command: |
+    grep -hxE '[[:space:]]*block([[:space:]].*)?' /etc/usbguard/rules.conf 2>/dev/null | wc -l
+  expected: '1'
+  expected_op: '>='
   sudo: true
-  fix: sudo systemctl enable --now apparmor
-  fix_sudo: true
-  affected_file: /etc/apparmor.d/
+  fix: 'Manual action required: Establish a baseline policy allowing only authorized devices and ending with a block rule.'
+  fix_sudo: false
+  affected_file: /etc/usbguard/rules.conf
   post_action: None
   security_level: high
-  risk_level: medium
-  risk_desc: Enabling AppArmor might block non-standard applications until a profile is created.
+  risk_level: high
+  risk_desc: Automatic creation of a restrictive policy may block required devices or disrupt workflows.


### PR DESCRIPTION
## Summary
 
Two changes to `operating_system/linux/`, one structural and one correctness.
 
**The guide is re-sequenced from a categorical layout into the order the controls are
actually applied in.** Previously a reader following it top to bottom hit the PAM password
stack in section 2 and full disk encryption in section 5, by which point encrypting the
disk means reinstalling. Worse, the PAM controls came before the `sudo` controls that make
them recoverable, so following the guide in order could leave an administrator unable to
authenticate and with no route to root. The content is now organised into eleven phases,
from firmware and disk layout through to verification, with a session safety protocol up
front and lockout warnings on the controls that can lock a user out.
 
**A number of checks in `ruleset.yaml` could not pass on a correctly hardened system.**
The audit rule checks required `-S` to follow `always,exit` directly, but every real
auditd rule places `-F arch=b64` in between; the mount option checks matched the option
order in `/etc/fstab` rather than the order the kernel reports; `/etc/resolv.conf`
permissions were read with `stat` on a symlink, which returns `777` on every
systemd-resolved system. These are fixed and verified against realistic inputs.
 
Nine checks that break core client functionality have been removed, and three that could
lock a user out have been reclassified or dropped. These are listed in full below, since
they are the changes a reviewer is most likely to want to argue with.
 
## Guide: order of application
 
| Phase | Scope |
| :--- | :--- |
| 0 | Preparation, backups, rescue media, session safety protocol |
| 1 | Firmware, partitioning, LUKS, bootloader, Secure Boot |
| 2 | Package integrity, microcode, kernel command line, boot-time bypasses |
| 3 | Administrative accounts and `sudo` |
| 4 | Hashing, password policy, aging, lockout, root restrictions |
| 5 | File system permissions and isolation |
| 6 | Kernel and network stack parameters |
| 7 | Service removal, firewalling, TCP wrappers |
| 8 | Time synchronisation, logging, audit rules, immutability |
| 9 | MAC, sandboxing, cron, session lock, USBGuard |
| 10 | Verification and maintenance |
 
Ordering decisions worth calling out:
 
- **LUKS and partitioning moved to Phase 1.** Both are install-time decisions. Retrofitting
  either means repartitioning, which cannot be automated or rolled back.
- **Phase 3 gates Phase 4.** `sudo` must be working and audited before any authentication
  control is tightened.
- **Time synchronisation moved ahead of all logging.** Audit rules were previously loaded
  before `chrony` was configured, so early log timestamps could not be correlated.
- **Immutable audit configuration moved to the end of Phase 8.** Once applied the rules
  cannot be changed without a reboot.
- **Service removal before firewalling.** A service that is not installed needs no rule.
Topic is still addressable: the `labels` field on each suite is unchanged, so
`--label filesystem` and friends behave as before. The suites in `ruleset.yaml` are stored
in the same phase order, so `fix --all` applies changes in the sequence the guide
describes rather than an arbitrary one.
 
### Session safety protocol
 
Phase 0 adds a protocol for the controls that can lock a user out: hold an existing
privileged shell open (it does not re-authenticate, so it survives a broken PAM stack),
apply the change elsewhere, verify in a third new session, and only then release the
safety net. Nine sections carry a warning pointing back to it: PAM password policy,
faillock, root lock, firewall, TCP wrappers, USBGuard, immutable audit configuration,
and GRUB passwords.
 
## Guide: corrections
 
- **The complete PAM password stack is now shown.** The guide described `pam_pwquality`,
  `pam_pwhistory` and `pam_unix` separately, stated that order matters, and never showed
  them assembled. Full stacks are given for Debian/Ubuntu and for the RHEL `authselect`
  profile, with a warning not to hand-edit the numeric jump in Debian's
  `[success=2 default=ignore]`.
- **`pwquality` parameters now point at the right file.** They were presented as PAM module
  arguments while the check reads `/etc/security/pwquality.conf`, so a reader following the
  guide failed the check.
- **`pam_pwhistory` names both files.** On the RHEL family the module must appear in
  `/etc/pam.d/system-auth` *and* `/etc/pam.d/password-auth`, or remote logins bypass the
  policy. Only `common-password` was mentioned.
- **`/etc/resolv.conf` is explained as a symlink.** The previous text said permissions
  protect "the link itself", which is not possible: a symlink's mode is always `0777` and
  `chmod` follows it. On resolver-managed systems the target lives on a `tmpfs` and is
  regenerated at boot, so a permission fix there does not persist.
- **Partitioning and mount options merged.** The material was split across two sections that
  duplicated each other.
- **Minimum password length was inconsistent**, given as 16 in one place and 14 in another.
  14 is now the floor, 16 the recommendation, and the check accepts anything at or above 14.
- Duplicated headings, orphaned section numbering and the em dashes introduced during
  editing have been cleaned up to match the surrounding house style.
## Ruleset: checks that could not pass
 
Each was verified against realistic input before and after.
 
| Check | Problem |
| :--- | :--- |
| the five `/etc/audit/rules.d` checks | required `-S` immediately after `always,exit`; real rules place `-F arch=b64` first. Verified: old patterns return 0 against a STIG-style ruleset |
| `mount-tmp-hardening`, `mount-home-hardening` (now removed as duplicates) | matched `nodev.*nosuid.*noexec` in that order; the kernel reports `rw,nosuid,nodev,noexec` |
| `65-resolv-conf-perms` | `stat` does not dereference symlinks, so it returned `777` on Ubuntu, Debian, Fedora and Arch, and `777 <= 644` is false |
| `82-fs-11-umask-profile` | read only `/etc/profile`, but the guide mandates a `/etc/profile.d/` drop-in |
| `40-auth-02-pass-complexity` | required the literal string `minlen=14`, so the guide's own `minlen=16` failed |
| `chrony-nts-config` | read only `/etc/chrony/chrony.conf`; the RHEL family uses `/etc/chrony.conf` |
| `syslog-critical-file-permissions` | read only `/var/log/auth.log`; the RHEL family uses `/var/log/secure` |
| `37-fs-04-bootloader-password` | read only `/boot/grub/grub.cfg`; the RHEL family and openSUSE use `/boot/grub2/` |
| `secure-boot-enabled` | used `sudo dmesg`, which this ruleset itself breaks by mandating `kernel.dmesg_restrict=1`; now reads the EFI variable |
 
### Command robustness
 
75 checks had a command whose final pipeline stage could exit non-zero: `grep -c` exits 1
on a zero count, `systemctl is-active` exits 3 when inactive, `cat /proc/sys/...` exits 1
for a knob absent on that kernel, `stat` exits 1 on a missing file. The runner reports a
non-zero exit as `command exited with code 1` and discards the output, so all of these were
indistinguishable from one another. In several cases the *compliant* result was the one
that errored, because it produced a count of zero.
 
Every command now exits 0 and prints exactly one value, including when the file or knob it
inspects does not exist. This is verified by executing all 129 of them.
 
Commands also discard stderr. The runner merged stderr into stdout and compared the
combined buffer against `expected`, so one unreadable file under `/etc/modprobe.d` made a
check fail regardless of system state. That is fixed in the tool as well
(mev0lent/hardener#3), but the ruleset no longer depends on the fix being present.
 
### Cross-distribution correctness
 
The false positives that a rootless container host produced are gone:
`audit-files-no-user` and `audit-files-no-group` now exclude IDs inside the ranges declared
in `/etc/subuid` and `/etc/subgid`. A user namespace maps container IDs into that range
precisely so they have no host account. On a test case matching a real report this takes
the count from 6192 to 3, keeping the genuinely orphaned files.
 
The remediation text for those two checks previously suggested `chown root <file>`, which
would have destroyed a rootless container installation. It now says explicitly not to do
that.
 
The modprobe blacklist checks used exact equality, so blacklisting a module in two files
produced a count of 2 and failed: being more thoroughly hardened scored worse. They now use
`>=`, and accept `install <mod> /bin/true` as well as `blacklist <mod>`.
 
## Controls removed for breaking core functionality
 
The guide is subtitled *Linux Clients*, and several inherited controls are server or
high-assurance measures that make a workstation unusable. Two of them had **automated**
fixes, so `hardener fix --all` applied them unattended.
 
| Removed check | Effect on a client |
| :--- | :--- |
| `32-mod-01-disable-usb-storage` | Wrote `install usb-storage /bin/true`, disabling every USB mass storage device on the machine, for every user, including USB3 drives via `uas`. Automated fix. |
| `21-kernel-08-userns-clone-disabled` | Wrote `kernel.unprivileged_userns_clone=0`. Its own `risk_desc` recorded that this breaks Flatpak and rootless containers, and it also disables the user-namespace sandboxes Chromium and Firefox rely on, so on a desktop it removes more protection than it adds. Automated fix. |
| `proc-hidepid-configured`, `proc-hidepid-runtime` | `hidepid=2` breaks `systemd --user`, polkit and the GNOME/KDE session unless `gid=` is configured correctly. The failure mode is no graphical login. |
| `pam-namespace-active`, `tmp-polyinstantiation-config` | A private `/tmp` per session breaks `/tmp/.X11-unix`, PulseAudio and PipeWire sockets and application IPC, and a misplaced `pam_namespace.so` line blocks login outright. On a single-user client it defends against a threat that does not arise. |
| `67-auth-15-pam-securetty`, `68-auth-16-securetty-config` | Obsolete. `/etc/securetty` no longer ships on current Debian and Ubuntu, and the RHEL family no longer references `pam_securetty` in its login stack. Re-creating it to satisfy an older benchmark risks blocking console and serial access, which on a machine with full disk encryption removes the only local recovery path. |
| `33-crypto-01-fips-mode` | A regulatory requirement rather than a client hardening control. It always fails on an ordinary client and its remediation can lock out SSH. |
 
The corresponding guide sections are not deleted. Each now explains why the control is not
used and, where relevant, how to apply it on a server instead, so that the omission reads
as a decision rather than an oversight.
 
`66-dns-secure-transport` was softened rather than removed. It required
`DNSOverTLS=yes`, which is strict mode: if any configured resolver lacks DNS-over-TLS
support, *all* name resolution fails, which on a client is indistinguishable from the
network being down. Guide and check now use `opportunistic`, which encrypts where
available and falls back rather than failing.
 
`shell-timeout` (`TMOUT`) was also removed. It is a server control, and the guide said so
while being subtitled *Linux Clients*: on a client the terminal lives inside the graphical
session, so the screen lock already denies access to it, while `readonly TMOUT` closes idle
shells inside `tmux`, terminals left at a prompt during a build, and open editor sessions.
 
## Reclassified rather than removed
 
Two checks moved from `baseline` to `high`, so a default `baseline` run skips them. Neither
is deleted.
 
- **`separate-partition-home` and `separate-partition-var`.** Retrofitting a separate
  filesystem means repartitioning: it cannot be automated, cannot be rolled back, and risks
  data loss. On a single-user client the benefit is modest, since `nodev` and `nosuid` block
  device nodes and SUID binaries, and creating either already requires root. The guide
  presents the layout as an install-time choice and keeps `nodev,nosuid` mandatory wherever
  the filesystem *is* separate.
**`pam-password-stack-order` was added.** If `pam_unix.so` precedes `pam_pwquality` and
`pam_pwhistory`, the password is already accepted and hashed before those modules run, so
they enforce nothing while every other check in the suite still passes. Nothing verified
the order.
 
The net is 44 suites and 129 checks, from 47 and 138.
 
## Testing
 
- All 129 commands executed directly: no non-zero exits, no multi-line output, no stderr.
- `ruleset.yaml` parsed with the tool's own `splitYAMLDocuments` and structs: 45 documents,
  0 failures, every suite carrying checks.
- Full `audit` run against the tool: 44 suites loaded and executed.
- `fix` and `rollback` exercised on a scratch file: change applied and restored.
- Guide: table of contents regenerated, 275 entries, no broken anchors and no headings
  missing from it.
## Scope
 
 
## Notes for reviewers
 
- The guide diff is large because sections moved. Reviewing it as a rendered document is
  likely easier than reading the diff; no section was dropped, and section content is
  unchanged except where listed above.
- The reference tool is https://github.com/mev0lent/hardener. Both files now state this
  explicitly, since the ruleset schema is specific to it and is not interchangeable with
  OpenSCAP, Lynis or CIS-CAT.
- **The suite order in `ruleset.yaml` is significant.** Sorting the file alphabetically or
  by id would apply the Phase 4 authentication controls before the Phase 3 `sudo` controls,
  which is how an administrator ends up without a route to root. The file carries no
  comments, so this is worth knowing before editing it.
- Everything was validated on Ubuntu. The distro-specific paths above are from
  documentation rather than from a run on each distribution, so RHEL, openSUSE and Arch
  spot-checks would be worth having.